### PR TITLE
Always show statistical evaluation tab

### DIFF
--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -427,14 +427,14 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 						ChangeState: async newState => {
 							if (newState === "STARTED") {
 								if (["ACTIVE", "EDITING", "STOPPED"].includes(this.state.quiz.state)) {
-									this.send(
-										`${actorUris.QuizRunActorPrefix}${this.quiz.orElse(toId("-"))}`,
-										QuizRunActorMessages.Clear()
-									);
-									this.send(
-										`${actorUris.StatsActorPrefix}${this.quiz.orElse(toId("-"))}`,
-										StatisticsActorMessages.Clear()
-									);
+									// this.send(
+									// 	`${actorUris.QuizRunActorPrefix}${this.quiz.orElse(toId("-"))}`,
+									// 	QuizRunActorMessages.Clear()
+									// );
+									// this.send(
+									// 	`${actorUris.StatsActorPrefix}${this.quiz.orElse(toId("-"))}`,
+									// 	StatisticsActorMessages.Clear()
+									// );
 									this.send(
 										actorUris.QuizActor,
 										QuizActorMessages.Update({

--- a/packages/frontend/src/pages/QuizPage.tsx
+++ b/packages/frontend/src/pages/QuizPage.tsx
@@ -137,9 +137,9 @@ export const QuizPage: React.FC = () => {
 	//     (quizData && quizData.quizStats && (quizData.quizStats.maximumParticipants ?? 0) > 0) ||
 	//     !!quizData?.questionStats;
 
-	const showStatTab =
-		mbQuiz.map(q => (q.quizStats?.maximumParticipants ?? 0) > 0).orElse(false) ||
-		mbQuiz.map(q => !!q.questionStats).orElse(false);
+	const showStatTab = true;
+	//	mbQuiz.map(q => (q.quizStats?.maximumParticipants ?? 0) > 0).orElse(false) ||
+	//	mbQuiz.map(q => !!q.questionStats).orElse(false);
 
 	// const isQuizStateEditing2 = quizData?.quiz?.state && quizData.quiz.state === "EDITING";
 	const isQuizStateEditing = mbQuiz.flatMap(q => maybe(q.quiz?.state)).orElse("STOPPED") === "EDITING";
@@ -500,7 +500,7 @@ export const QuizPage: React.FC = () => {
 								</Tab>
 								{/* {showStatTab && (isQuizTeacher ? true : isQuizCompleted ) && ( */}
 								{showStatTab &&
-									(isUserInTeachersList ? true : isQuizCompleted && studentsCanSeeStatistics) && (
+									(isUserInTeachersList || (isQuizCompleted && studentsCanSeeStatistics)) && (
 										<Tab
 											eventKey={tabRecords.statistics.value}
 											title={i18n._(tabRecords.statistics.label)}


### PR DESCRIPTION
- always show the statistical evaluation tab, even if there's no data yet
- starting the quiz does *not* clear the statistics anymore. There is an extra button to clear the stats manually.