### PR TITLE
Hotfix Can only click on stats detaiils when availible

### DIFF
--- a/packages/frontend/src/components/quiz-tabs/QuizStatsTab.tsx
+++ b/packages/frontend/src/components/quiz-tabs/QuizStatsTab.tsx
@@ -185,8 +185,8 @@ export const QuizStatsTab: React.FC<{ quizData: CurrentQuizState }> = ({ quizDat
 																textUnderlineOffset: "3px",
 																// color: $primary
 															}}
-															onClick={() =>
-																tryActor.forEach(actor =>
+															// Only activate question stats if there are details available
+															onClick={() => noDetails ? null : tryActor.forEach(actor =>
 																	actor.send(
 																		actor,
 																		CurrentQuizMessages.ActivateQuestionStats(


### PR DESCRIPTION
The statistics details are only clickable when there are answers available, now. I want to change this in future do the question details are viewable, but this is a hotfix to solve the error when there's no data.