### PR TITLE
Feature/docker debian slim wkhtmltopdf install

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -3,10 +3,13 @@ FROM node:20-slim
 # Install wkhtmltopdf + minimal deps, then clean up apt caches
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-      wkhtmltopdf \
-      fontconfig \
-      ttf-dejavu \
-      ca-certificates \
+      wkhtmltopdf         \
+      fontconfig          \
+      fonts-dejavu-core   \
+      ca-certificates     \
+      libx11-6            \
+      libxrender1         \
+      libxext6            \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,4 +1,13 @@
-FROM node:20-alpine
+FROM node:20-slim
+
+# Install wkhtmltopdf + minimal deps, then clean up apt caches
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      wkhtmltopdf \
+      fontconfig \
+      ttf-dejavu \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
chore(docker): switch to node:20-slim and install wkhtmltopdf

- Change base image from node:20-alpine to node:20-slim
- Install wkhtmltopdf, fontconfig, ttf-dejavu, and ca-certificates via apt
- Remove Alpine-specific dependencies and keep existing build steps intact