### PR TITLE
fix: resolve pre-existing ESLint errors in frontend

### DIFF
--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -20,6 +20,7 @@
     "rules": {
         "react/react-in-jsx-scope": "off",
         "react/prop-types": "off",
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "index": "off", 
         // "indent": [
         //     "error",

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -286,11 +286,10 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 
 	async receive(_from: ActorRef, message: MessageType): Promise<Unit | boolean | QuizRun> {
 		const maybeLocalMessage = await this.handleRemoteUpdates(message);
-		try {
-			// Deal with local messages
-			return maybeLocalMessage
-				.map(m =>
-					CurrentQuizMessages.match<Promise<Unit | boolean | QuizRun>>(m, {
+		// Deal with local messages
+		return maybeLocalMessage
+			.map(m =>
+				CurrentQuizMessages.match<Promise<Unit | boolean | QuizRun>>(m, {
 						Reset: async () => {
 							this.updateState(draft => {
 								draft.quiz = {} as Quiz;
@@ -789,7 +788,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 										);
 
 										// Distinguish the “no run” case
-										if ((run as any)?.message === "No run for user") {
+										if ((run as Error)?.message === "No run for user") {
 											d.run({ quizId, studentIdHash: anonUserKey(studentId), action: "error", error: "no-run" });
 										} else {
 											d.run({ quizId, studentIdHash: anonUserKey(studentId), action: "ok" });
@@ -938,8 +937,5 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 					})
 				)
 				.orElse(Promise.resolve(unit()));
-		} catch (e) {
-			throw e;
-		}
 	}
 }

--- a/packages/frontend/src/actors/ErrorActor.ts
+++ b/packages/frontend/src/actors/ErrorActor.ts
@@ -26,7 +26,7 @@ const errorIds = {
 
 export class ErrorActor extends StatefulActor<ErrorMessage, Unit, { error: string }> {
 	protected state = { error: "" };
-	protected pingTimer: any;
+	protected pingTimer: ReturnType<typeof setTimeout> | undefined;
 
 	public constructor(name: string, system: ActorSystem) {
 		super(name, system);

--- a/packages/frontend/src/actors/LocalUserActor.ts
+++ b/packages/frontend/src/actors/LocalUserActor.ts
@@ -115,7 +115,7 @@ export class LocalUserActor extends StatefulActor<Messages, Unit | string, Local
 				});
 			}
 		} else if (message.tag == "QuizUpdateMessage") {
-			const names: any[] = message.quiz.teachers
+			const names: { username: string }[] = message.quiz.teachers
 				? await this.ask(actorUris.UserStore, UserStoreMessages.GetNames(message.quiz.teachers))
 				: [];
 			this.updateState(draft => {
@@ -154,9 +154,9 @@ export class LocalUserActor extends StatefulActor<Messages, Unit | string, Local
 					userRole: undefined,
 				})
 			);
-			if ((result as any).message) {
+			if ((result as Error).message) {
 				this.updateState(draft => {
-					draft.error = (result as any).message;
+					draft.error = (result as Error).message;
 				});
 			} else {
 				this.updateState(draft => {

--- a/packages/frontend/src/actors/TokenActor.ts
+++ b/packages/frontend/src/actors/TokenActor.ts
@@ -7,7 +7,7 @@ import { cookie } from "../utils";
 import { d } from "../utils/debugLog";
 
 export class TokenActor extends Actor<unknown, Unit> {
-  public interval: any;
+  public interval: ReturnType<typeof setTimeout> | undefined;
   private expiresAt: Date;
 
   public constructor(name: string, system: ActorSystem) {
@@ -64,7 +64,7 @@ export class TokenActor extends Actor<unknown, Unit> {
 
     clearTimeout(this.interval); // Clear previous timeout
 
-    // clamp to at least 1 s to avoid tight loops
+    // clamp to at least 1s to avoid tight loops
     const safeDelay = Math.max(delay, 1_000);
     if (delay <= 0) {
       console.warn("[TokenActor] Computed delay <= 0, forcing retry in 1 s");

--- a/packages/frontend/src/components/TooltipWrapper.tsx
+++ b/packages/frontend/src/components/TooltipWrapper.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import React, { PropsWithChildren } from "react";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/Tooltip";
 import { Placement } from "react-bootstrap/esm/types";
@@ -14,7 +14,7 @@ export const TooltipWrapper = ({ placement = "top", title, children }: Props) =>
             placement={placement}
             overlay={title ? <Tooltip>{title}</Tooltip> : <></>}
         >
-            {children as any}
+            {children as React.ReactElement}
         </OverlayTrigger>
     );
 };

--- a/packages/frontend/src/components/layout/UserParticipationSelect.tsx
+++ b/packages/frontend/src/components/layout/UserParticipationSelect.tsx
@@ -60,7 +60,7 @@ export const UserParticipationSelect = (props: Props) => {
         },
     };
     if (props.temporary) {
-        delete (userParticipationOptions as any).NAME;
+        delete (userParticipationOptions as Record<string, unknown>).NAME;
     }
 
     useEffect(() => {

--- a/packages/frontend/src/components/modals/CommentEditorModal.tsx
+++ b/packages/frontend/src/components/modals/CommentEditorModal.tsx
@@ -120,7 +120,7 @@ export const CommentEditorModal: React.FC<Props> = ({
                             value={value}
                             onChange={val => setValue(val ?? "")}
                             height="100%"
-                            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                             
                             components={{ preview: (_source, _state, _dispath) => <></> }}
                             preview="edit"
                         />

--- a/packages/frontend/src/components/modals/MarkdownModal.tsx
+++ b/packages/frontend/src/components/modals/MarkdownModal.tsx
@@ -52,7 +52,7 @@ export const MarkdownModal: React.FC<Props> = ({ show, titleId, editorValue, onC
                             value={value}
                             onChange={val => setValue(val ?? "")}
                             height="100%"
-                            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                             
                             components={{ preview: (_source, _state, _dispatch) => <></> }}
                             preview="edit"
                         />

--- a/packages/frontend/src/components/navigation/Root.tsx
+++ b/packages/frontend/src/components/navigation/Root.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
-import { i18n } from "@lingui/core";
 import { Trans } from "@lingui/react";
 import { Layout } from "../../layout/Layout";
 import { SystemContext } from "ts-actors-react";

--- a/packages/frontend/src/components/quiz-tabs/QuizDataTab.tsx
+++ b/packages/frontend/src/components/quiz-tabs/QuizDataTab.tsx
@@ -19,7 +19,7 @@ import axios from "axios";
 import { QuizExportModal } from "../modals/QuizExportModal";
 import { ButtonWithTooltip } from "../ButtonWithTooltip";
 import { ShareQuizModal } from "../modals/ShareQuizModal";
-import { checkIsCreatingQuestionDisabled, checkIsParticipationDisabled, debounce } from "../../utils";
+import { checkIsCreatingQuestionDisabled, debounce } from "../../utils";
 import { CharacterTracker } from "../CharacterTracker";
 import { DESCRIPTION_MAX_CHARACTERS, TITLE_MAX_CHARACTERS, TITLE_MIN_CHARACTERS } from "../../constants/constants";
 import { useCurrentQuiz } from "../../hooks/state-actor/useCurrentQuiz";
@@ -108,7 +108,6 @@ export const QuizDataTab: React.FC<Props> = props => {
 	const isTitleAndDescriptionDisabled = props.disableForStudent || disabledByMode;
 
 	const isCreatingQuestionDisabled = checkIsCreatingQuestionDisabled(quiz.allowedQuestionTypesSettings);
-	const isParticipationDisabled = checkIsParticipationDisabled(quiz.studentParticipationSettings);
 
 	return (
 		<Form>

--- a/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
+++ b/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
@@ -215,7 +215,7 @@ export const RunningQuizTab: React.FC<{
 										value={textAnswer}
 										onChange={val => setTextAnswer(val ?? "")}
 										height="100%"
-										// eslint-disable-next-line @typescript-eslint/no-unused-vars
+										
 										components={{ preview: (_source, _state, _dispath) => <></> }}
 										preview="edit"
 									/>

--- a/packages/frontend/src/components/quizzes-panel/QuizCard.tsx
+++ b/packages/frontend/src/components/quizzes-panel/QuizCard.tsx
@@ -5,7 +5,7 @@ import { i18n } from "@lingui/core";
 import { fromTimestamp } from "itu-utils";
 import { Quiz, QuestionGroup, toId } from "@recapp/models";
 import Card from "react-bootstrap/Card";
-import { Pencil, Play, Share, Trash, StopFill } from "react-bootstrap-icons";
+import { Play, Share, Trash, StopFill } from "react-bootstrap-icons";
 import { ButtonWithTooltip } from "../ButtonWithTooltip";
 import { QuizStateBadge } from "../QuizStateBadge";
 import { useLocalUser } from "../../hooks/state-actor/useLocalUser";
@@ -30,8 +30,6 @@ export const QuizCard: React.FC<{
 	const isAuthorized = isAdmin || isQuizTeacher;
 
 	const isQuizStateStarted = quiz.state === "STARTED";
-	const isStudentQuestionAllowed = !!quiz.studentQuestions;
-	const isQuizEditable = !isQuizStateStarted && (isAuthorized || isStudentQuestionAllowed);
 
 	const navigateToQuizPage = () => {
 		nav({ pathname: "/Dashboard/quiz" }, { state: { quizId: quiz.uid } });

--- a/packages/frontend/src/pages/QuestionEdit.tsx
+++ b/packages/frontend/src/pages/QuestionEdit.tsx
@@ -77,7 +77,7 @@ export const QuestionEdit: React.FC = () => {
 		hasInitialQuestions: false,
 		questionsSubscribed: false,
 	});
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	
 	const q = mbQuiz.map(q => q.quiz).orUndefined();
 	const isQuizStateStarted = q?.state === "STARTED";
 	const isQuizStateEditing = q?.state === "EDITING";
@@ -804,7 +804,7 @@ export const QuestionEdit: React.FC = () => {
 										onChange={val => setQuestion(prev => ({ ...prev, text: val ?? "" }))}
 										height="100%"
 										style={{ padding: 6 }}
-										// eslint-disable-next-line @typescript-eslint/no-unused-vars
+										
 										components={{ preview: (_source, _state, _dispatch) => <></> }}
 										preview="edit"
 									/>
@@ -894,7 +894,7 @@ export const QuestionEdit: React.FC = () => {
 										setQuestion(state => {
 											console.log({ state });
 
-											// eslint-disable-next-line @typescript-eslint/no-explicit-any
+											
 											// (state as any)[showTextModal.property] = text;
 											return { ...state, hint: text };
 										});

--- a/packages/frontend/src/pages/QuizPage.tsx
+++ b/packages/frontend/src/pages/QuizPage.tsx
@@ -1,7 +1,6 @@
 // packages/frontend/src/pages/QuizPage.tsx
 
 import { Fragment, useEffect, useRef, useState } from "react";
-import type { Question } from "@recapp/models";
 import { i18n } from "@lingui/core";
 import { useActorSystem, useStatefulActor } from "ts-actors-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
@@ -287,7 +286,6 @@ export const QuizPage: React.FC = () => {
 				console.log("TL", isUserInTeachersList, quizData.quiz.previewers);
 
 				const runReady = !!quizData.runReady;
-				const hasInitialQuestions = !!quizData.hasInitialQuestions;
 				const isQuizStateStarted = quizData.quiz.state === "STARTED";
 
 				// if (!isQuizStateStarted) {
@@ -304,7 +302,7 @@ export const QuizPage: React.FC = () => {
 				// }
 
 				const run = quizData.run;
-				const qData = quizData.questions;runReady
+				const qData = quizData.questions;runReady;
 				const questions = run?.questions.map(id => qData.find(q => q.uid === id)) ?? [];
 				const currentQuestion = questions[run?.counter ?? 0];
 				const questionId = currentQuestion?.uid ?? toId("");

--- a/packages/frontend/src/system.ts
+++ b/packages/frontend/src/system.ts
@@ -36,7 +36,6 @@ export const system = DistributedActorSystem.create({ distributor, systemName: s
 		const ta = await s.createActor(TokenActor, { name: "TokenActor" });
 		actorUris["TokenActor"] = toActorUri(ta.name);
 
-		const sa = s.getActorRef(`actors://${s.systemName}`);
 		return s;
 	} catch (e) {
 		console.error(e);

--- a/packages/frontend/src/utils/debugLog.ts
+++ b/packages/frontend/src/utils/debugLog.ts
@@ -63,8 +63,8 @@ export function dlog<T extends BaseLog>(
 ) {
   if (!enabled) return;
   const line = { tag, ts: new Date().toISOString(), ...payload };
-  // eslint-disable-next-line no-console
-  ((window as any).DEBUG_LOGS ||= []).push(line);
+
+  ((window as Window & { DEBUG_LOGS?: unknown[] }).DEBUG_LOGS ||= []).push(line);
   console.info(JSON.stringify(line));
 }
 


### PR DESCRIPTION
I let an LLM clean up issues found by the linter.

- Remove useless try/catch wrapper in CurrentQuizActor.receive
- Replace `any` casts with proper types: `Error`, `ReturnType<typeof setTimeout>`, `{ username: string }[]`, `Record<string, unknown>`, `React.ReactElement`, and a typed Window extension
- Remove unused variables: `i18n` (Root.tsx), `isParticipationDisabled` (QuizDataTab), `Pencil`/`isQuizEditable` (QuizCard), `Question` (QuizPage), `hasInitialQuestions` shadow (QuizPage), `sa` (system.ts)
- Fix irregular whitespace (Unicode thin space) in TokenActor.ts comment
- Add `argsIgnorePattern: "^_"` to no-unused-vars rule to allow intentionally unused `_`-prefixed parameters in method overrides
- Remove unused eslint-disable directives left stale by the above fixes