### PR TITLE
test(models): add schema unit tests

### DIFF
--- a/packages/models/test/base.test.ts
+++ b/packages/models/test/base.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { Timestamp } from "itu-utils";
+import {
+	timestampSchema,
+	uidSchema,
+	actorUriSchema,
+	idEntitySchema,
+	toId,
+	toActorUri,
+	validationOkay,
+} from "../src/data/base";
+
+const validRawTs = { value: 1_700_000_000_000, type: "Timestamp" as const };
+
+describe("timestampSchema", () => {
+	it("transforms a valid raw object into a Timestamp instance", () => {
+		const result = timestampSchema.parse(validRawTs);
+		expect(result).toBeInstanceOf(Timestamp);
+		expect(result.value).toBe(validRawTs.value);
+	});
+
+	it("rejects a non-integer value", () => {
+		expect(() => timestampSchema.parse({ value: 1.5, type: "Timestamp" })).toThrow();
+	});
+
+	it("rejects wrong tag", () => {
+		expect(() => timestampSchema.parse({ value: 0, type: "Other" })).toThrow();
+	});
+
+	it("rejects missing value field", () => {
+		expect(() => timestampSchema.parse({ type: "Timestamp" })).toThrow();
+	});
+
+	it("rejects missing type field", () => {
+		expect(() => timestampSchema.parse({ value: 1_700_000_000_000 })).toThrow();
+	});
+
+	it("accepts zero as value (epoch)", () => {
+		const result = timestampSchema.parse({ value: 0, type: "Timestamp" });
+		expect(result.value).toBe(0);
+	});
+
+	it("rejects a string value", () => {
+		expect(() => timestampSchema.parse({ value: "not-a-number", type: "Timestamp" })).toThrow();
+	});
+});
+
+describe("uidSchema", () => {
+	it("parses a normal string", () => {
+		const id = uidSchema.parse("abc-123");
+		expect(id).toBe("abc-123");
+	});
+
+	it("rejects a number", () => {
+		expect(() => uidSchema.parse(42)).toThrow();
+	});
+
+	it("rejects null", () => {
+		expect(() => uidSchema.parse(null)).toThrow();
+	});
+
+	it("accepts an empty string (no min-length constraint)", () => {
+		expect(uidSchema.parse("")).toBe("");
+	});
+});
+
+describe("actorUriSchema", () => {
+	it("parses a valid URI string", () => {
+		const uri = actorUriSchema.parse("akka://system@host:2551/user/myActor");
+		expect(uri).toBe("akka://system@host:2551/user/myActor");
+	});
+
+	it("rejects a number", () => {
+		expect(() => actorUriSchema.parse(9)).toThrow();
+	});
+});
+
+describe("toId / toActorUri helpers", () => {
+	it("toId returns the string unchanged", () => {
+		expect(toId("my-uid")).toBe("my-uid");
+	});
+
+	it("toActorUri returns the string unchanged", () => {
+		expect(toActorUri("akka://sys/user/x")).toBe("akka://sys/user/x");
+	});
+});
+
+describe("idEntitySchema", () => {
+	const validEntity = {
+		uid: "uid-1",
+		created: validRawTs,
+		updated: validRawTs,
+	};
+
+	it("parses a minimal entity without archived", () => {
+		const result = idEntitySchema.parse(validEntity);
+		expect(result.uid).toBe("uid-1");
+		expect(result.created).toBeInstanceOf(Timestamp);
+		expect(result.updated).toBeInstanceOf(Timestamp);
+		expect(result.archived).toBeUndefined();
+	});
+
+	it("parses an entity with archived set", () => {
+		const result = idEntitySchema.parse({ ...validEntity, archived: validRawTs });
+		expect(result.archived).toBeInstanceOf(Timestamp);
+	});
+
+	it("rejects missing uid", () => {
+		const { uid: _uid, ...rest } = validEntity;
+		expect(() => idEntitySchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing created", () => {
+		const { created: _c, ...rest } = validEntity;
+		expect(() => idEntitySchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing updated", () => {
+		const { updated: _u, ...rest } = validEntity;
+		expect(() => idEntitySchema.parse(rest)).toThrow();
+	});
+
+	it("rejects a non-string uid", () => {
+		expect(() => idEntitySchema.parse({ ...validEntity, uid: 99 })).toThrow();
+	});
+});
+
+describe("validationOkay", () => {
+	it("returns true when all values are true", () => {
+		expect(validationOkay({ a: true, b: true, c: true })).toBe(true);
+	});
+
+	it("returns false when any value is false", () => {
+		expect(validationOkay({ a: true, b: false, c: true })).toBe(false);
+	});
+
+	it("returns false when all values are false", () => {
+		expect(validationOkay({ x: false })).toBe(false);
+	});
+
+	it("returns true for an empty object (vacuously)", () => {
+		expect(validationOkay({})).toBe(true);
+	});
+});

--- a/packages/models/test/comment.test.ts
+++ b/packages/models/test/comment.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { commentSchema } from "../src/data/comment";
+
+const validRawTs = { value: 1_700_000_000_000, type: "Timestamp" as const };
+
+const validComment = {
+	uid: "comment-1",
+	created: validRawTs,
+	updated: validRawTs,
+	authorId: "user-1",
+	authorName: "Alice",
+	text: "Great question!",
+	upvoters: [],
+	answered: false,
+	relatedQuiz: "quiz-1",
+};
+
+describe("commentSchema", () => {
+	it("parses a minimal valid comment", () => {
+		const result = commentSchema.parse(validComment);
+		expect(result.uid).toBe("comment-1");
+		expect(result.authorName).toBe("Alice");
+		expect(result.answered).toBe(false);
+		expect(result.upvoters).toHaveLength(0);
+		expect(result.relatedQuestion).toBeUndefined();
+	});
+
+	it("parses a comment with relatedQuestion", () => {
+		const result = commentSchema.parse({ ...validComment, relatedQuestion: "q-99" });
+		expect(result.relatedQuestion).toBe("q-99");
+	});
+
+	it("parses a comment with multiple upvoters", () => {
+		const result = commentSchema.parse({
+			...validComment,
+			upvoters: ["user-2", "user-3"],
+		});
+		expect(result.upvoters).toHaveLength(2);
+	});
+
+	it("accepts answered: true", () => {
+		const result = commentSchema.parse({ ...validComment, answered: true });
+		expect(result.answered).toBe(true);
+	});
+
+	it("rejects missing authorId", () => {
+		const { authorId: _a, ...rest } = validComment;
+		expect(() => commentSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing authorName", () => {
+		const { authorName: _a, ...rest } = validComment;
+		expect(() => commentSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing text", () => {
+		const { text: _t, ...rest } = validComment;
+		expect(() => commentSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing relatedQuiz", () => {
+		const { relatedQuiz: _r, ...rest } = validComment;
+		expect(() => commentSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-boolean answered", () => {
+		expect(() => commentSchema.parse({ ...validComment, answered: "yes" })).toThrow();
+	});
+
+	it("rejects non-string entries in upvoters", () => {
+		expect(() =>
+			commentSchema.parse({ ...validComment, upvoters: [123] })
+		).toThrow();
+	});
+
+	it("rejects missing upvoters field", () => {
+		const { upvoters: _u, ...rest } = validComment;
+		expect(() => commentSchema.parse(rest)).toThrow();
+	});
+});

--- a/packages/models/test/quiz.test.ts
+++ b/packages/models/test/quiz.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect } from "vitest";
+import {
+	answerSchema,
+	questionTypesSchema,
+	questionSchema,
+	questionGroupSchema,
+	runOptionsSchema,
+	quizRunSchema,
+	quizSchema,
+	testPackage,
+	examAnswer,
+	examFeedback,
+	isInTeachersList,
+	isInStudentList,
+} from "../src/data/quiz";
+import { toId } from "../src/data/base";
+import type { Quiz } from "../src/data/quiz";
+
+const validRawTs = { value: 1_700_000_000_000, type: "Timestamp" as const };
+const baseEntity = { uid: "ent-1", created: validRawTs, updated: validRawTs };
+
+const participationSettings = { NAME: true, NICKNAME: true, ANONYMOUS: false };
+const questionTypesSettings = { SINGLE: true, MULTIPLE: true, TEXT: false };
+
+const validQuizBase = {
+	...baseEntity,
+	title: "My Quiz",
+	description: "A test quiz",
+	state: "EDITING" as const,
+	uniqueLink: "my-quiz-link",
+	groups: [],
+	comments: [],
+	studentQuestions: true,
+	studentComments: false,
+	studentParticipationSettings: participationSettings,
+	allowedQuestionTypesSettings: questionTypesSettings,
+	shuffleQuestions: false,
+	teachers: ["teacher-1"],
+	students: [],
+};
+
+// ─── answerSchema ────────────────────────────────────────────────────────────
+
+describe("answerSchema", () => {
+	it("parses a correct answer", () => {
+		const result = answerSchema.parse({ text: "Paris", correct: true });
+		expect(result.text).toBe("Paris");
+		expect(result.correct).toBe(true);
+	});
+
+	it("parses an incorrect answer", () => {
+		const result = answerSchema.parse({ text: "Berlin", correct: false });
+		expect(result.correct).toBe(false);
+	});
+
+	it("rejects missing text", () => {
+		expect(() => answerSchema.parse({ correct: true })).toThrow();
+	});
+
+	it("rejects missing correct", () => {
+		expect(() => answerSchema.parse({ text: "Paris" })).toThrow();
+	});
+
+	it("rejects non-boolean correct", () => {
+		expect(() => answerSchema.parse({ text: "Paris", correct: "true" })).toThrow();
+	});
+});
+
+// ─── questionTypesSchema ──────────────────────────────────────────────────────
+
+describe("questionTypesSchema", () => {
+	it.each(["SINGLE", "MULTIPLE", "TEXT"] as const)("accepts %s", type => {
+		expect(questionTypesSchema.parse(type)).toBe(type);
+	});
+
+	it("rejects unknown type", () => {
+		expect(() => questionTypesSchema.parse("OPEN")).toThrow();
+	});
+});
+
+// ─── questionSchema ───────────────────────────────────────────────────────────
+
+describe("questionSchema", () => {
+	const validQuestion = {
+		...baseEntity,
+		text: "What is the capital of France?",
+		type: "SINGLE" as const,
+		authorId: "user-1",
+		quiz: "quiz-1",
+		answers: [
+			{ text: "Paris", correct: true },
+			{ text: "Berlin", correct: false },
+		],
+		approved: true,
+		editMode: false,
+	};
+
+	it("parses a minimal valid question", () => {
+		const result = questionSchema.parse(validQuestion);
+		expect(result.text).toBe("What is the capital of France?");
+		expect(result.type).toBe("SINGLE");
+		expect(result.approved).toBe(true);
+		expect(result.editMode).toBe(false);
+		expect(result.answerOrderFixed).toBe(false); // default
+		expect(result.hint).toBeUndefined();
+		expect(result.statistics).toBeUndefined();
+	});
+
+	it("parses a TEXT question with empty answers", () => {
+		const result = questionSchema.parse({ ...validQuestion, type: "TEXT", answers: [] });
+		expect(result.answers).toHaveLength(0);
+	});
+
+	it("parses optional hint and authorName", () => {
+		const result = questionSchema.parse({
+			...validQuestion,
+			hint: "Think about European capitals",
+			authorName: "Prof. Alice",
+			authorFingerprint: "fp-abc",
+		});
+		expect(result.hint).toBe("Think about European capitals");
+		expect(result.authorName).toBe("Prof. Alice");
+		expect(result.authorFingerprint).toBe("fp-abc");
+	});
+
+	it("applies answerOrderFixed default of false", () => {
+		const result = questionSchema.parse(validQuestion);
+		expect(result.answerOrderFixed).toBe(false);
+	});
+
+	it("accepts answerOrderFixed: true", () => {
+		const result = questionSchema.parse({ ...validQuestion, answerOrderFixed: true });
+		expect(result.answerOrderFixed).toBe(true);
+	});
+
+	it("rejects missing text", () => {
+		const { text: _t, ...rest } = validQuestion;
+		expect(() => questionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing type", () => {
+		const { type: _t, ...rest } = validQuestion;
+		expect(() => questionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects invalid type", () => {
+		expect(() => questionSchema.parse({ ...validQuestion, type: "ESSAY" })).toThrow();
+	});
+
+	it("rejects missing quiz", () => {
+		const { quiz: _q, ...rest } = validQuestion;
+		expect(() => questionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-boolean approved", () => {
+		expect(() => questionSchema.parse({ ...validQuestion, approved: 1 })).toThrow();
+	});
+
+	it("rejects non-array answers", () => {
+		expect(() => questionSchema.parse({ ...validQuestion, answers: "wrong" })).toThrow();
+	});
+});
+
+// ─── questionGroupSchema ──────────────────────────────────────────────────────
+
+describe("questionGroupSchema", () => {
+	it("parses a valid group with questions", () => {
+		const result = questionGroupSchema.parse({
+			name: "Chapter 1",
+			questions: ["q-1", "q-2"],
+		});
+		expect(result.name).toBe("Chapter 1");
+		expect(result.questions).toHaveLength(2);
+		expect(result.statistics).toBeUndefined();
+	});
+
+	it("parses a group with empty questions", () => {
+		const result = questionGroupSchema.parse({ name: "Empty", questions: [] });
+		expect(result.questions).toHaveLength(0);
+	});
+
+	it("rejects missing name", () => {
+		expect(() => questionGroupSchema.parse({ questions: [] })).toThrow();
+	});
+
+	it("rejects non-string question IDs", () => {
+		expect(() =>
+			questionGroupSchema.parse({ name: "G", questions: [1, 2] })
+		).toThrow();
+	});
+});
+
+// ─── runOptionsSchema ─────────────────────────────────────────────────────────
+
+describe("runOptionsSchema", () => {
+	it("parses empty run options", () => {
+		const result = runOptionsSchema.parse({});
+		expect(result.runningEntity).toBeUndefined();
+	});
+
+	it("parses run options with a runningEntity", () => {
+		const result = runOptionsSchema.parse({ runningEntity: "q-1" });
+		expect(result.runningEntity).toBe("q-1");
+	});
+});
+
+// ─── quizRunSchema ────────────────────────────────────────────────────────────
+
+describe("quizRunSchema", () => {
+	const validRun = {
+		...baseEntity,
+		studentId: "student-1",
+		quizId: "quiz-1",
+		questions: ["q-1", "q-2"],
+		counter: 0,
+		answers: ["my text answer", [true, false, null]],
+		correct: [true],
+		wrong: [false],
+	};
+
+	it("parses a valid quiz run", () => {
+		const result = quizRunSchema.parse(validRun);
+		expect(result.studentId).toBe("student-1");
+		expect(result.counter).toBe(0);
+		expect(result.questions).toHaveLength(2);
+	});
+
+	it("parses string answers (text questions)", () => {
+		const result = quizRunSchema.parse({
+			...validRun,
+			answers: ["free text", "another answer"],
+		});
+		expect(result.answers[0]).toBe("free text");
+	});
+
+	it("parses boolean array answers (choice questions)", () => {
+		const result = quizRunSchema.parse({
+			...validRun,
+			answers: [[true, false, null]],
+		});
+		expect(Array.isArray(result.answers[0])).toBe(true);
+	});
+
+	it("rejects float for counter", () => {
+		expect(() => quizRunSchema.parse({ ...validRun, counter: 1.5 })).toThrow();
+	});
+
+	it("rejects missing studentId", () => {
+		const { studentId: _s, ...rest } = validRun;
+		expect(() => quizRunSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing quizId", () => {
+		const { quizId: _q, ...rest } = validRun;
+		expect(() => quizRunSchema.parse(rest)).toThrow();
+	});
+
+	it("accepts empty questions and answers arrays", () => {
+		const result = quizRunSchema.parse({
+			...validRun,
+			questions: [],
+			answers: [],
+			correct: [],
+			wrong: [],
+		});
+		expect(result.questions).toHaveLength(0);
+	});
+});
+
+// ─── quizSchema ───────────────────────────────────────────────────────────────
+
+describe("quizSchema", () => {
+	it("parses a minimal valid quiz", () => {
+		const result = quizSchema.parse(validQuizBase);
+		expect(result.title).toBe("My Quiz");
+		expect(result.state).toBe("EDITING");
+		expect(result.shuffleAnswers).toBe(false); // default
+		expect(result.hideComments).toBe(false); // default
+		expect(result.previewers).toBeUndefined();
+	});
+
+	it.each(["EDITING", "ACTIVE", "STARTED", "STOPPED"] as const)(
+		"accepts state %s",
+		state => {
+			const result = quizSchema.parse({ ...validQuizBase, state });
+			expect(result.state).toBe(state);
+		}
+	);
+
+	it("rejects unknown state", () => {
+		expect(() => quizSchema.parse({ ...validQuizBase, state: "PAUSED" })).toThrow();
+	});
+
+	it("applies shuffleAnswers default of false", () => {
+		const result = quizSchema.parse(validQuizBase);
+		expect(result.shuffleAnswers).toBe(false);
+	});
+
+	it("accepts shuffleAnswers: true", () => {
+		const result = quizSchema.parse({ ...validQuizBase, shuffleAnswers: true });
+		expect(result.shuffleAnswers).toBe(true);
+	});
+
+	it("applies hideComments default of false", () => {
+		const result = quizSchema.parse(validQuizBase);
+		expect(result.hideComments).toBe(false);
+	});
+
+	it("parses optional previewers array", () => {
+		const result = quizSchema.parse({ ...validQuizBase, previewers: ["user-5"] });
+		expect(result.previewers).toEqual(["user-5"]);
+	});
+
+	it("parses optional studentsCanSeeStatistics", () => {
+		const result = quizSchema.parse({ ...validQuizBase, studentsCanSeeStatistics: true });
+		expect(result.studentsCanSeeStatistics).toBe(true);
+	});
+
+	it("parses runOptions", () => {
+		const result = quizSchema.parse({
+			...validQuizBase,
+			runOptions: { runningEntity: "group-1" },
+		});
+		expect(result.runOptions?.runningEntity).toBe("group-1");
+	});
+
+	it("parses groups with questions", () => {
+		const result = quizSchema.parse({
+			...validQuizBase,
+			groups: [{ name: "G1", questions: ["q-1"] }],
+		});
+		expect(result.groups).toHaveLength(1);
+	});
+
+	it("rejects missing title", () => {
+		const { title: _t, ...rest } = validQuizBase;
+		expect(() => quizSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing teachers array", () => {
+		const { teachers: _t, ...rest } = validQuizBase;
+		expect(() => quizSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-boolean studentQuestions", () => {
+		expect(() =>
+			quizSchema.parse({ ...validQuizBase, studentQuestions: "yes" })
+		).toThrow();
+	});
+
+	it("rejects non-boolean shuffleQuestions", () => {
+		expect(() =>
+			quizSchema.parse({ ...validQuizBase, shuffleQuestions: 1 })
+		).toThrow();
+	});
+});
+
+// ─── isInTeachersList / isInStudentList ────────────────────────────────────────
+
+describe("isInTeachersList and isInStudentList", () => {
+	const makeQuiz = (overrides: Record<string, unknown>): Quiz =>
+		quizSchema.parse({ ...validQuizBase, ...overrides }) as Quiz;
+
+	it("isInTeachersList is true when user is a teacher and not a previewer", () => {
+		const quiz = makeQuiz({ teachers: ["t-1", "t-2"], previewers: [] });
+		expect(isInTeachersList(quiz, toId("t-1"))).toBe(true);
+	});
+
+	it("isInTeachersList is false when user is also in previewers", () => {
+		const quiz = makeQuiz({ teachers: ["t-1"], previewers: ["t-1"] });
+		expect(isInTeachersList(quiz, toId("t-1"))).toBe(false);
+	});
+
+	it("isInTeachersList is false when user is not in teachers list", () => {
+		const quiz = makeQuiz({ teachers: ["t-1"] });
+		expect(isInTeachersList(quiz, toId("other"))).toBe(false);
+	});
+
+	it("isInStudentList is true when user is in students", () => {
+		const quiz = makeQuiz({ students: ["s-1", "s-2"] });
+		expect(isInStudentList(quiz, toId("s-1"))).toBe(true);
+	});
+
+	it("isInStudentList is true when user is a previewer", () => {
+		const quiz = makeQuiz({ students: [], previewers: ["t-1"] });
+		expect(isInStudentList(quiz, toId("t-1"))).toBe(true);
+	});
+
+	it("isInStudentList is false when user is neither student nor previewer", () => {
+		const quiz = makeQuiz({ students: ["s-1"], previewers: [] });
+		expect(isInStudentList(quiz, toId("other"))).toBe(false);
+	});
+});
+
+// ─── testPackage ──────────────────────────────────────────────────────────────
+
+describe("testPackage", () => {
+	const validQuestion = {
+		...baseEntity,
+		text: "Q1",
+		type: "SINGLE" as const,
+		authorId: "user-1",
+		quiz: "quiz-1",
+		answers: [{ text: "A", correct: true }],
+		approved: true,
+		editMode: false,
+	};
+
+	it("parses a valid test package", () => {
+		const result = testPackage.parse({
+			studentId: "s-1",
+			quizId: "quiz-1",
+			elements: [validQuestion],
+		});
+		expect(result.studentId).toBe("s-1");
+		expect(result.elements).toHaveLength(1);
+	});
+
+	it("parses a test package with empty elements", () => {
+		const result = testPackage.parse({
+			studentId: "s-1",
+			quizId: "quiz-1",
+			elements: [],
+		});
+		expect(result.elements).toHaveLength(0);
+	});
+
+	it("rejects missing studentId", () => {
+		expect(() =>
+			testPackage.parse({ quizId: "quiz-1", elements: [] })
+		).toThrow();
+	});
+});
+
+// ─── examAnswer ───────────────────────────────────────────────────────────────
+
+describe("examAnswer", () => {
+	it("parses a string answer (text question)", () => {
+		const result = examAnswer.parse({
+			studentId: "s-1",
+			quizId: "quiz-1",
+			elementId: "q-1",
+			answers: "my text answer",
+		});
+		expect(result.answers).toBe("my text answer");
+	});
+
+	it("parses an array-of-int answer (choice question)", () => {
+		const result = examAnswer.parse({
+			studentId: "s-1",
+			quizId: "quiz-1",
+			elementId: "q-1",
+			answers: [0, 2],
+		});
+		expect(result.answers).toEqual([0, 2]);
+	});
+
+	it("rejects float indices in answers array", () => {
+		expect(() =>
+			examAnswer.parse({
+				studentId: "s-1",
+				quizId: "quiz-1",
+				elementId: "q-1",
+				answers: [0.5],
+			})
+		).toThrow();
+	});
+
+	it("rejects missing answers field", () => {
+		expect(() =>
+			examAnswer.parse({ studentId: "s-1", quizId: "quiz-1", elementId: "q-1" })
+		).toThrow();
+	});
+});
+
+// ─── examFeedback ─────────────────────────────────────────────────────────────
+
+describe("examFeedback", () => {
+	it("parses a PASSED feedback", () => {
+		const result = examFeedback.parse({
+			studentId: "s-1",
+			quizId: "quiz-1",
+			elementId: "q-1",
+			result: "PASSED",
+			answers: new Set([0, 1]),
+			correct: new Set([0]),
+		});
+		expect(result.result).toBe("PASSED");
+		expect(result.answers.has(0)).toBe(true);
+		expect(result.correct.has(0)).toBe(true);
+	});
+
+	it("parses a FAILED feedback", () => {
+		const result = examFeedback.parse({
+			studentId: "s-1",
+			quizId: "quiz-1",
+			elementId: "q-1",
+			result: "FAILED",
+			answers: new Set([2]),
+			correct: new Set([1]),
+		});
+		expect(result.result).toBe("FAILED");
+	});
+
+	it("rejects unknown result value", () => {
+		expect(() =>
+			examFeedback.parse({
+				studentId: "s-1",
+				quizId: "quiz-1",
+				elementId: "q-1",
+				result: "PARTIAL",
+				answers: new Set([0]),
+				correct: new Set([0]),
+			})
+		).toThrow();
+	});
+
+	it("rejects answers as plain array (must be a Set)", () => {
+		expect(() =>
+			examFeedback.parse({
+				studentId: "s-1",
+				quizId: "quiz-1",
+				elementId: "q-1",
+				result: "PASSED",
+				answers: [0, 1],
+				correct: new Set([0]),
+			})
+		).toThrow();
+	});
+
+	it("rejects float entries in answers set", () => {
+		expect(() =>
+			examFeedback.parse({
+				studentId: "s-1",
+				quizId: "quiz-1",
+				elementId: "q-1",
+				result: "PASSED",
+				answers: new Set([0.5]),
+				correct: new Set([0]),
+			})
+		).toThrow();
+	});
+});

--- a/packages/models/test/session.test.ts
+++ b/packages/models/test/session.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { Timestamp } from "itu-utils";
+import { fingerprintSchema, sessionSchema } from "../src/data/session";
+
+const validRawTs = { value: 1_700_000_000_000, type: "Timestamp" as const };
+
+describe("fingerprintSchema", () => {
+	const valid = {
+		uid: "fp-abc123",
+		created: validRawTs,
+		updated: validRawTs,
+		lastSeen: validRawTs,
+		usageCount: 5,
+		blocked: false,
+		userUid: "user-1",
+	};
+
+	it("parses a minimal fingerprint", () => {
+		const result = fingerprintSchema.parse(valid);
+		expect(result.uid).toBe("fp-abc123");
+		expect(result.usageCount).toBe(5);
+		expect(result.blocked).toBe(false);
+		expect(result.lastSeen).toBeInstanceOf(Timestamp);
+		expect(result.initialQuiz).toBeUndefined();
+	});
+
+	it("parses fingerprint with initialQuiz", () => {
+		const result = fingerprintSchema.parse({ ...valid, initialQuiz: "quiz-42" });
+		expect(result.initialQuiz).toBe("quiz-42");
+	});
+
+	it("rejects float usageCount", () => {
+		expect(() => fingerprintSchema.parse({ ...valid, usageCount: 1.5 })).toThrow();
+	});
+
+	it("rejects missing blocked", () => {
+		const { blocked: _b, ...rest } = valid;
+		expect(() => fingerprintSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing userUid", () => {
+		const { userUid: _u, ...rest } = valid;
+		expect(() => fingerprintSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-boolean blocked", () => {
+		expect(() => fingerprintSchema.parse({ ...valid, blocked: 0 })).toThrow();
+	});
+
+	it("rejects missing lastSeen", () => {
+		const { lastSeen: _l, ...rest } = valid;
+		expect(() => fingerprintSchema.parse(rest)).toThrow();
+	});
+});
+
+describe("sessionSchema", () => {
+	const valid = {
+		idToken: "eyJ...",
+		accessToken: "eyJ...",
+		refreshToken: "eyJ...",
+		uid: "user-1",
+		idExpires: validRawTs,
+		refreshExpires: validRawTs,
+		actorSystem: "akka://recapp@host:2551",
+		role: "STUDENT" as const,
+		created: validRawTs,
+		updated: validRawTs,
+	};
+
+	it("parses a minimal valid session", () => {
+		const result = sessionSchema.parse(valid);
+		expect(result.uid).toBe("user-1");
+		expect(result.role).toBe("STUDENT");
+		expect(result.idExpires).toBeInstanceOf(Timestamp);
+		expect(result.fingerprint).toBeUndefined();
+		expect(result.persistentCookie).toBeUndefined();
+	});
+
+	it("parses session with fingerprint and persistentCookie", () => {
+		const result = sessionSchema.parse({
+			...valid,
+			fingerprint: "fp-xyz",
+			persistentCookie: true,
+		});
+		expect(result.fingerprint).toBe("fp-xyz");
+		expect(result.persistentCookie).toBe(true);
+	});
+
+	it.each(["STUDENT", "TEACHER", "ADMIN"] as const)("accepts role %s", role => {
+		const result = sessionSchema.parse({ ...valid, role });
+		expect(result.role).toBe(role);
+	});
+
+	it("rejects unknown role", () => {
+		expect(() => sessionSchema.parse({ ...valid, role: "GUEST" })).toThrow();
+	});
+
+	it("rejects missing idToken", () => {
+		const { idToken: _i, ...rest } = valid;
+		expect(() => sessionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing accessToken", () => {
+		const { accessToken: _a, ...rest } = valid;
+		expect(() => sessionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing refreshToken", () => {
+		const { refreshToken: _r, ...rest } = valid;
+		expect(() => sessionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing uid", () => {
+		const { uid: _u, ...rest } = valid;
+		expect(() => sessionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing actorSystem", () => {
+		const { actorSystem: _a, ...rest } = valid;
+		expect(() => sessionSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-string idToken", () => {
+		expect(() => sessionSchema.parse({ ...valid, idToken: 123 })).toThrow();
+	});
+});

--- a/packages/models/test/statistics.test.ts
+++ b/packages/models/test/statistics.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+	textElementStatisticsSchema,
+	choiceElementStatisticsSchema,
+	groupStatisticsSchema,
+} from "../src/data/statistics";
+
+const validRawTs = { value: 1_700_000_000_000, type: "Timestamp" as const };
+
+const baseEntity = {
+	uid: "stat-1",
+	created: validRawTs,
+	updated: validRawTs,
+};
+
+describe("textElementStatisticsSchema", () => {
+	const valid = {
+		...baseEntity,
+		tag: "TextElementStatistics" as const,
+		questionId: "q-1",
+		groupName: "Group A",
+		quizId: "quiz-1",
+		maximumParticipants: 30,
+		participants: 20,
+		answers: ["answer 1", "answer 2"],
+		wrong: 5,
+	};
+
+	it("parses a valid text statistics object", () => {
+		const result = textElementStatisticsSchema.parse(valid);
+		expect(result.tag).toBe("TextElementStatistics");
+		expect(result.participants).toBe(20);
+		expect(result.answers).toHaveLength(2);
+	});
+
+	it("rejects wrong tag", () => {
+		expect(() =>
+			textElementStatisticsSchema.parse({ ...valid, tag: "ChoiceElementStatistics" })
+		).toThrow();
+	});
+
+	it("rejects float for maximumParticipants", () => {
+		expect(() =>
+			textElementStatisticsSchema.parse({ ...valid, maximumParticipants: 10.5 })
+		).toThrow();
+	});
+
+	it("rejects float for participants", () => {
+		expect(() =>
+			textElementStatisticsSchema.parse({ ...valid, participants: 1.1 })
+		).toThrow();
+	});
+
+	it("rejects float for wrong", () => {
+		expect(() =>
+			textElementStatisticsSchema.parse({ ...valid, wrong: 0.9 })
+		).toThrow();
+	});
+
+	it("accepts empty answers array", () => {
+		const result = textElementStatisticsSchema.parse({ ...valid, answers: [] });
+		expect(result.answers).toHaveLength(0);
+	});
+
+	it("rejects non-string entries in answers", () => {
+		expect(() =>
+			textElementStatisticsSchema.parse({ ...valid, answers: [42] })
+		).toThrow();
+	});
+
+	it("rejects missing questionId", () => {
+		const { questionId: _q, ...rest } = valid;
+		expect(() => textElementStatisticsSchema.parse(rest)).toThrow();
+	});
+});
+
+describe("choiceElementStatisticsSchema", () => {
+	const valid = {
+		...baseEntity,
+		tag: "ChoiceElementStatistics" as const,
+		questionId: "q-2",
+		groupName: "Group B",
+		quizId: "quiz-1",
+		maximumParticipants: 30,
+		participants: 25,
+		passed: 18,
+		answers: [10, 8, 7],
+		wrong: 2,
+	};
+
+	it("parses a valid choice statistics object", () => {
+		const result = choiceElementStatisticsSchema.parse(valid);
+		expect(result.tag).toBe("ChoiceElementStatistics");
+		expect(result.passed).toBe(18);
+		expect(result.answers).toEqual([10, 8, 7]);
+	});
+
+	it("rejects wrong tag", () => {
+		expect(() =>
+			choiceElementStatisticsSchema.parse({ ...valid, tag: "TextElementStatistics" })
+		).toThrow();
+	});
+
+	it("rejects float in answers array", () => {
+		expect(() =>
+			choiceElementStatisticsSchema.parse({ ...valid, answers: [1.5, 2] })
+		).toThrow();
+	});
+
+	it("rejects float for passed", () => {
+		expect(() =>
+			choiceElementStatisticsSchema.parse({ ...valid, passed: 3.3 })
+		).toThrow();
+	});
+
+	it("accepts zero participants and zero wrong", () => {
+		const result = choiceElementStatisticsSchema.parse({
+			...valid,
+			participants: 0,
+			wrong: 0,
+			passed: 0,
+			answers: [],
+		});
+		expect(result.participants).toBe(0);
+	});
+
+	it("rejects missing passed field", () => {
+		const { passed: _p, ...rest } = valid;
+		expect(() => choiceElementStatisticsSchema.parse(rest)).toThrow();
+	});
+});
+
+describe("groupStatisticsSchema", () => {
+	const valid = {
+		groupName: "Overall",
+		quizId: "quiz-1",
+		maximumParticipants: 50,
+		answers: [40, 45, 30],
+		correctAnswers: [35, 40, 25],
+		questionIds: ["q-1", "q-2", "q-3"],
+		wrongAnswers: [5, 5, 5],
+	};
+
+	it("parses a valid group statistics object", () => {
+		const result = groupStatisticsSchema.parse(valid);
+		expect(result.groupName).toBe("Overall");
+		expect(result.questionIds).toHaveLength(3);
+	});
+
+	it("accepts empty arrays", () => {
+		const result = groupStatisticsSchema.parse({
+			...valid,
+			answers: [],
+			correctAnswers: [],
+			questionIds: [],
+			wrongAnswers: [],
+		});
+		expect(result.answers).toHaveLength(0);
+	});
+
+	it("rejects floats in correctAnswers", () => {
+		expect(() =>
+			groupStatisticsSchema.parse({ ...valid, correctAnswers: [1.1] })
+		).toThrow();
+	});
+
+	it("rejects floats in wrongAnswers", () => {
+		expect(() =>
+			groupStatisticsSchema.parse({ ...valid, wrongAnswers: [0.5] })
+		).toThrow();
+	});
+
+	it("rejects missing groupName", () => {
+		const { groupName: _g, ...rest } = valid;
+		expect(() => groupStatisticsSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing quizId", () => {
+		const { quizId: _q, ...rest } = valid;
+		expect(() => groupStatisticsSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-integer maximumParticipants", () => {
+		expect(() =>
+			groupStatisticsSchema.parse({ ...valid, maximumParticipants: 10.5 })
+		).toThrow();
+	});
+});

--- a/packages/models/test/user.test.ts
+++ b/packages/models/test/user.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { Timestamp } from "itu-utils";
+import { userRoleSchema, userParticipationSchema, userSchema } from "../src/data/user";
+
+const validRawTs = { value: 1_700_000_000_000, type: "Timestamp" as const };
+
+const validUser = {
+	uid: "user-1",
+	created: validRawTs,
+	updated: validRawTs,
+	role: "TEACHER" as const,
+	username: "teacher@example.com",
+	lastLogin: validRawTs,
+	active: true,
+	quizUsage: new Map(),
+};
+
+describe("userRoleSchema", () => {
+	it.each(["STUDENT", "TEACHER", "ADMIN"] as const)("accepts %s", role => {
+		expect(userRoleSchema.parse(role)).toBe(role);
+	});
+
+	it("rejects an unknown role", () => {
+		expect(() => userRoleSchema.parse("MODERATOR")).toThrow();
+	});
+
+	it("rejects empty string", () => {
+		expect(() => userRoleSchema.parse("")).toThrow();
+	});
+});
+
+describe("userParticipationSchema", () => {
+	it.each(["NAME", "NICKNAME", "ANONYMOUS"] as const)("accepts %s", mode => {
+		expect(userParticipationSchema.parse(mode)).toBe(mode);
+	});
+
+	it("rejects an unknown participation type", () => {
+		expect(() => userParticipationSchema.parse("GUEST")).toThrow();
+	});
+});
+
+describe("userSchema", () => {
+	it("parses a minimal valid user", () => {
+		const result = userSchema.parse(validUser);
+		expect(result.uid).toBe("user-1");
+		expect(result.role).toBe("TEACHER");
+		expect(result.username).toBe("teacher@example.com");
+		expect(result.active).toBe(true);
+		expect(result.lastLogin).toBeInstanceOf(Timestamp);
+		expect(result.isTemporary).toBe(false); // default
+		expect(result.quizUsage).toBeInstanceOf(Map);
+	});
+
+	it("parses optional nickname and email", () => {
+		const result = userSchema.parse({
+			...validUser,
+			nickname: "Prof. X",
+			email: "x@uni.edu",
+		});
+		expect(result.nickname).toBe("Prof. X");
+		expect(result.email).toBe("x@uni.edu");
+	});
+
+	it("accepts STUDENT role", () => {
+		const result = userSchema.parse({ ...validUser, role: "STUDENT" });
+		expect(result.role).toBe("STUDENT");
+	});
+
+	it("applies isTemporary default of false", () => {
+		const result = userSchema.parse(validUser);
+		expect(result.isTemporary).toBe(false);
+	});
+
+	it("accepts isTemporary: true", () => {
+		const result = userSchema.parse({ ...validUser, isTemporary: true, fingerprint: "fp-abc" });
+		expect(result.isTemporary).toBe(true);
+		expect(result.fingerprint).toBe("fp-abc");
+	});
+
+	it("accepts initialQuiz field", () => {
+		const result = userSchema.parse({ ...validUser, initialQuiz: "quiz-99" });
+		expect(result.initialQuiz).toBe("quiz-99");
+	});
+
+	it("parses quizUsage map with entries", () => {
+		const quizUsage = new Map([
+			["quiz-1", { type: "ANONYMOUS" as const }],
+			["quiz-2", { type: "NAME" as const, name: "Alice" }],
+		]);
+		const result = userSchema.parse({ ...validUser, quizUsage });
+		expect(result.quizUsage.size).toBe(2);
+	});
+
+	it("rejects an invalid role", () => {
+		expect(() => userSchema.parse({ ...validUser, role: "SUPERUSER" })).toThrow();
+	});
+
+	it("rejects missing username", () => {
+		const { username: _u, ...rest } = validUser;
+		expect(() => userSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects missing lastLogin", () => {
+		const { lastLogin: _l, ...rest } = validUser;
+		expect(() => userSchema.parse(rest)).toThrow();
+	});
+
+	it("rejects non-boolean active", () => {
+		expect(() => userSchema.parse({ ...validUser, active: "yes" })).toThrow();
+	});
+
+	it("rejects quizUsage as plain object (must be a Map)", () => {
+		expect(() => userSchema.parse({ ...validUser, quizUsage: {} })).toThrow();
+	});
+});


### PR DESCRIPTION
165 tests across 6 files cover all Zod schemas in packages/models/src/data/: base (timestampSchema, uidSchema, actorUriSchema, idEntitySchema, validationOkay), user, statistics, comment, session, and quiz (answerSchema, questionSchema, quizRunSchema, quizSchema, testPackage, examAnswer, examFeedback, helper fns). Each schema is tested for valid input, missing required fields, wrong types, and boundary/default values.