### PR TITLE
Add frontend unit tests for utils, actors, and components 

### DIFF
--- a/packages/frontend/test/actorMocks.ts
+++ b/packages/frontend/test/actorMocks.ts
@@ -1,0 +1,28 @@
+/**
+ * Factory helpers for mocking useStatefulActor() return values in component tests.
+ *
+ * useStatefulActor<T>() returns [Maybe<T>, Try<ActorRef>].
+ * Both are tsmonad types — they must be real instances, not plain objects,
+ * because components call .map(), .forEach(), .orElse() on them.
+ */
+import { vi } from "vitest";
+import { maybe, nothing, Success } from "tsmonads";
+import type { ActorRef } from "ts-actors";
+import type { Maybe } from "tsmonads";
+
+export type MockActorRef = Pick<ActorRef, "name" | "isShutdown"> & { send: ReturnType<typeof vi.fn> };
+
+export function makeMockActorRef(): MockActorRef {
+	return { name: "mock-actor", isShutdown: false, send: vi.fn() };
+}
+
+/** Return value when actor state is available */
+export function withState<T>(state: T, actorRef?: MockActorRef): [Maybe<T>, Success<MockActorRef>] {
+	const ref = actorRef ?? makeMockActorRef();
+	return [maybe(state) as Maybe<T>, new Success(ref)];
+}
+
+/** Return value when actor is not yet ready (nothing state) */
+export function withNoState<T>(): [ReturnType<typeof nothing>, ReturnType<typeof nothing>] {
+	return [nothing(), nothing()];
+}

--- a/packages/frontend/test/actors/CreateQuizActor.test.ts
+++ b/packages/frontend/test/actors/CreateQuizActor.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ActorSystem } from "ts-actors";
+import { CreateQuizActor, CreateQuizMessages, CreateQuizState } from "../../src/actors/CreateQuizActor";
+import { actorUris } from "../../src/actorUris";
+import { toActorUri } from "@recapp/models";
+import { createStub, getActorState } from "./stubs";
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+describe("CreateQuizActor — Update (validation)", () => {
+	let system: ActorSystem;
+	let ref: Awaited<ReturnType<typeof system.createActor>>;
+
+	beforeEach(async () => {
+		system = await ActorSystem.create({ systemName: "test", logger: silentLogger as any });
+		ref = await system.createActor(CreateQuizActor, { name: "CreateQuiz" });
+	});
+
+	afterEach(async () => {
+		await system.shutdown();
+	});
+
+	const state = () => getActorState<CreateQuizState>(system, "CreateQuiz");
+
+	it("starts with empty title and title validation false", () => {
+		expect(state().quiz.title).toBe("");
+		expect(state().validation.title).toBe(false);
+	});
+
+	it("Update with a title of >= 1 char sets validation.title to true", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "My Quiz" }));
+		expect(state().validation.title).toBe(true);
+	});
+
+	it("Update with empty title keeps validation.title false", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "" }));
+		expect(state().validation.title).toBe(false);
+	});
+
+	it("Update with whitespace-only title keeps validation.title false", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "   " }));
+		expect(state().validation.title).toBe(false);
+	});
+
+	it("Update merges partial updates into quiz state", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "Quiz A", description: "Desc" }));
+		const s = state();
+		expect(s.quiz.title).toBe("Quiz A");
+		expect(s.quiz.description).toBe("Desc");
+	});
+
+	it("ResetData restores empty title and false validation", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "Quiz A" }));
+		await system.ask(ref, CreateQuizMessages.ResetData());
+		const s = state();
+		expect(s.quiz.title).toBe("");
+		expect(s.validation.title).toBe(false);
+	});
+});
+
+describe("CreateQuizActor — CreateQuiz", () => {
+	let system: ActorSystem;
+	let ref: Awaited<ReturnType<typeof system.createActor>>;
+	// Save and restore actorUris entries we override
+	let savedLocalUser: string | undefined;
+	let savedQuizActor: string | undefined;
+
+	beforeEach(async () => {
+		savedLocalUser = actorUris["LocalUser"];
+		savedQuizActor = actorUris["QuizActor"];
+		system = await ActorSystem.create({ systemName: "test", logger: silentLogger as any });
+
+		// Register stub actors and point actorUris to them
+		actorUris["LocalUser"] = toActorUri(await createStub(system, "LocalUser", () => "uid-teacher-1"));
+		actorUris["QuizActor"] = toActorUri(await createStub(system, "QuizActor", () => "new-quiz-uid"));
+
+		ref = await system.createActor(CreateQuizActor, { name: "CreateQuiz" });
+	});
+
+	afterEach(async () => {
+		actorUris["LocalUser"] = savedLocalUser as any;
+		actorUris["QuizActor"] = savedQuizActor as any;
+		await system.shutdown();
+	});
+
+	const state = () => getActorState<CreateQuizState>(system, "CreateQuiz");
+
+	it("CreateQuiz rejects when validation fails (empty title)", async () => {
+		// ts-actors ask() rejects when the actor's receive() returns an Error instance
+		await expect(system.ask(ref, CreateQuizMessages.CreateQuiz())).rejects.toThrow(/not validated/i);
+	});
+
+	it("CreateQuiz succeeds and returns a uid when title is valid", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "Valid Quiz" }));
+		const result = await system.ask(ref, CreateQuizMessages.CreateQuiz());
+		expect(result).toBe("new-quiz-uid");
+	});
+
+	it("CreateQuiz resets form state on success", async () => {
+		await system.ask(ref, CreateQuizMessages.Update({ title: "Valid Quiz" }));
+		await system.ask(ref, CreateQuizMessages.CreateQuiz());
+		// Give the async ResetData send time to process
+		await new Promise(r => setTimeout(r, 50));
+		expect(state().quiz.title).toBe("");
+		expect(state().validation.title).toBe(false);
+	});
+});

--- a/packages/frontend/test/actors/ErrorActor.test.ts
+++ b/packages/frontend/test/actors/ErrorActor.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ActorSystem } from "ts-actors";
+import { ErrorActor, ErrorMessages } from "../../src/actors/ErrorActor";
+import { getActorState } from "./stubs";
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+describe("ErrorActor", () => {
+	let system: ActorSystem;
+	let ref: Awaited<ReturnType<typeof system.createActor>>;
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		system = await ActorSystem.create({ systemName: "test", logger: silentLogger as any });
+		ref = await system.createActor(ErrorActor, { name: "ErrorActor" });
+	});
+
+	afterEach(async () => {
+		await system.shutdown();
+		vi.useRealTimers();
+	});
+
+	const state = () => getActorState<{ error: string }>(system, "ErrorActor");
+
+	it("starts with empty error string", () => {
+		expect(state().error).toBe("");
+	});
+
+	it("SetError with 'deactivated' message sets the deactivated error id", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("user deactivated")));
+		expect(state().error).toBe("error-message-user-deactivated");
+	});
+
+	it("SetError with 'expired' message sets the session-expired error id", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("session expired")));
+		expect(state().error).toBe("error-message-session-expired");
+	});
+
+	it("SetError with 'rpc' message sets the no-server-connection error id", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("rpc call failed")));
+		expect(state().error).toBe("error-message-no-server-connection");
+	});
+
+	it("SetError with 'unknown' keyword sets the unknown error id", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("unknown actor error")));
+		expect(state().error).toBe("error-unknown-error-occured");
+	});
+
+	it("SetError with unrecognized message returns empty string (no match)", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("something completely different")));
+		expect(state().error).toBe("");
+	});
+
+	it("SetError is case-insensitive", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("Session EXPIRED now")));
+		expect(state().error).toBe("error-message-session-expired");
+	});
+
+	it("ResetError clears the error", async () => {
+		await system.ask(ref, ErrorMessages.SetError(new Error("rpc error")));
+		await system.ask(ref, ErrorMessages.ResetError());
+		expect(state().error).toBe("");
+	});
+
+	it("LogWarning does not change state", async () => {
+		await system.ask(ref, ErrorMessages.LogWarning("watch out"));
+		expect(state().error).toBe("");
+	});
+});

--- a/packages/frontend/test/actors/SharingActor.test.ts
+++ b/packages/frontend/test/actors/SharingActor.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ActorSystem } from "ts-actors";
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+import { SharingActor, SharingMessages, SharingState } from "../../src/actors/SharingActor";
+import { actorUris } from "../../src/actorUris";
+import { toActorUri, toId } from "@recapp/models";
+import { createStub, getActorState } from "./stubs";
+
+describe("SharingActor — synchronous operations", () => {
+	let system: ActorSystem;
+	let ref: Awaited<ReturnType<typeof system.createActor>>;
+
+	beforeEach(async () => {
+		system = await ActorSystem.create({ systemName: "test", logger: silentLogger as any });
+		ref = await system.createActor(SharingActor, { name: "QuizSharing" });
+	});
+
+	afterEach(async () => {
+		await system.shutdown();
+	});
+
+	const state = () => getActorState<SharingState>(system, "QuizSharing");
+
+	it("starts with empty teachers and errors", () => {
+		expect(state().teachers).toEqual([]);
+		expect(state().errors).toEqual([]);
+	});
+
+	it("AddExisting replaces teacher list", async () => {
+		await system.ask(ref, SharingMessages.AddExisting([
+			{ uid: toId("u1"), name: "Alice" },
+			{ uid: toId("u2"), name: "Bob" },
+		]));
+		expect(state().teachers).toHaveLength(2);
+		expect(state().teachers[0]).toMatchObject({ uid: "u1", name: "Alice" });
+	});
+
+	it("AddExisting replaces (not appends) on second call", async () => {
+		await system.ask(ref, SharingMessages.AddExisting([{ uid: toId("u1"), name: "Alice" }]));
+		await system.ask(ref, SharingMessages.AddExisting([{ uid: toId("u2"), name: "Bob" }]));
+		expect(state().teachers).toHaveLength(1);
+		expect(state().teachers[0].uid).toBe("u2");
+	});
+
+	it("DeleteEntry removes a teacher by uid", async () => {
+		await system.ask(ref, SharingMessages.AddExisting([
+			{ uid: toId("u1"), name: "Alice" },
+			{ uid: toId("u2"), name: "Bob" },
+		]));
+		await system.ask(ref, SharingMessages.DeleteEntry(toId("u1")));
+		expect(state().teachers).toHaveLength(1);
+		expect(state().teachers[0].uid).toBe("u2");
+	});
+
+	it("DeleteEntry is a no-op for unknown uid", async () => {
+		await system.ask(ref, SharingMessages.AddExisting([{ uid: toId("u1"), name: "Alice" }]));
+		await system.ask(ref, SharingMessages.DeleteEntry(toId("unknown")));
+		expect(state().teachers).toHaveLength(1);
+	});
+
+	it("DeleteError removes an error by id", async () => {
+		// Seed an error directly by exploiting the fact that errors get pushed on 'not found'
+		// We'll use a stub for UserStore to trigger it in the async test suite instead.
+		// Here just confirm the list is initially empty.
+		expect(state().errors).toHaveLength(0);
+	});
+
+	it("Clear keeps teachers with a valid uid", async () => {
+		// AddExisting gives teachers a uid; Clear keeps those.
+		await system.ask(ref, SharingMessages.AddExisting([
+			{ uid: toId("u1"), name: "Alice" },
+		]));
+		await system.ask(ref, SharingMessages.Clear());
+		expect(state().teachers).toHaveLength(1);
+	});
+});
+
+describe("SharingActor — AddEntry (async, with UserStore stub)", () => {
+	let system: ActorSystem;
+	let ref: Awaited<ReturnType<typeof system.createActor>>;
+	let savedUserStore: string | undefined;
+
+	beforeEach(async () => {
+		savedUserStore = actorUris["UserStore"];
+		system = await ActorSystem.create({ systemName: "test", logger: silentLogger as any });
+	});
+
+	afterEach(async () => {
+		actorUris["UserStore"] = savedUserStore as any;
+		await system.shutdown();
+	});
+
+	const state = () => getActorState<SharingState>(system, "QuizSharing");
+
+	const waitForState = (predicate: () => boolean) =>
+		new Promise<void>((resolve, reject) => {
+			const deadline = Date.now() + 1000;
+			const poll = () => {
+				if (predicate()) return resolve();
+				if (Date.now() > deadline) return reject(new Error("timed out waiting for state"));
+				setTimeout(poll, 10);
+			};
+			poll();
+		});
+
+	it("AddEntry adds teacher when UserStore returns a user", async () => {
+		actorUris["UserStore"] = toActorUri(
+			await createStub(system, "UserStore", () => ({ uid: "u1", username: "Alice" }))
+		);
+		ref = await system.createActor(SharingActor, { name: "QuizSharing" });
+
+		await system.ask(ref, SharingMessages.AddEntry("alice@example.com"));
+		await waitForState(() => state().teachers.length > 0);
+
+		expect(state().teachers).toHaveLength(1);
+		expect(state().teachers[0]).toMatchObject({ uid: "u1", name: "Alice" });
+	});
+
+	it("AddEntry records a not-found error when UserStore returns no uid", async () => {
+		actorUris["UserStore"] = toActorUri(
+			await createStub(system, "UserStore", () => ({ error: "not found" }))
+		);
+		ref = await system.createActor(SharingActor, { name: "QuizSharing" });
+
+		await system.ask(ref, SharingMessages.AddEntry("nobody@example.com"));
+		await waitForState(() => state().errors.length > 0);
+
+		const errors = state().errors;
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toMatchObject({ queryNotFound: "nobody@example.com" });
+	});
+
+	it("AddEntry records an already-exists error for duplicate teacher", async () => {
+		actorUris["UserStore"] = toActorUri(
+			await createStub(system, "UserStore", () => ({ uid: "u1", username: "Alice" }))
+		);
+		ref = await system.createActor(SharingActor, { name: "QuizSharing" });
+
+		// Add once successfully
+		await system.ask(ref, SharingMessages.AddEntry("alice@example.com"));
+		await waitForState(() => state().teachers.length === 1);
+
+		// Add the same person again
+		await system.ask(ref, SharingMessages.AddEntry("alice@example.com"));
+		await waitForState(() => state().errors.length > 0);
+
+		expect(state().teachers).toHaveLength(1);
+		expect(state().errors[0]).toMatchObject({ alreadyExists: "Alice" });
+	});
+
+	it("DeleteError removes the error by id", async () => {
+		actorUris["UserStore"] = toActorUri(
+			await createStub(system, "UserStore", () => ({ error: "not found" }))
+		);
+		ref = await system.createActor(SharingActor, { name: "QuizSharing" });
+
+		await system.ask(ref, SharingMessages.AddEntry("nobody@example.com"));
+		await waitForState(() => state().errors.length > 0);
+		const errorId = state().errors[0].id;
+
+		await system.ask(ref, SharingMessages.DeleteError(errorId));
+		expect(state().errors).toHaveLength(0);
+	});
+});

--- a/packages/frontend/test/actors/stubs.ts
+++ b/packages/frontend/test/actors/stubs.ts
@@ -1,0 +1,43 @@
+import { Actor } from "ts-actors";
+import type { ActorRef, ActorSystem } from "ts-actors";
+import { toActorUri } from "@recapp/models";
+
+/**
+ * A generic stub actor that delegates receive() to a provided handler.
+ * Use with system.createActor(StubActor, { name: "..." }, handlerFn).
+ */
+export class StubActor extends Actor<unknown, unknown> {
+	constructor(
+		name: string,
+		system: ActorSystem,
+		public readonly handler: (msg: unknown) => unknown = () => undefined
+	) {
+		super(name, system);
+	}
+
+	async receive(_from: ActorRef, message: unknown): Promise<unknown> {
+		return this.handler(message);
+	}
+}
+
+/**
+ * Register a stub actor in the system and return its URI string.
+ * The URI is actors://<systemName>/<name>.
+ */
+export async function createStub(
+	system: ActorSystem,
+	name: string,
+	handler: (msg: unknown) => unknown = () => undefined
+): Promise<string> {
+	await system.createActor(StubActor, { name }, handler);
+	return toActorUri(`actors://${(system as any).systemName}/${name}`);
+}
+
+/**
+ * Read the protected `state` from a StatefulActor via the ActorSystem.
+ */
+export function getActorState<T>(system: ActorSystem, actorName: string): T {
+	const ref = system.getActorRef(`actors://${(system as any).systemName}/${actorName}`) as any;
+	if (ref instanceof Error) throw ref;
+	return ref.actor.state as T;
+}

--- a/packages/frontend/test/components/CharacterTracker.test.tsx
+++ b/packages/frontend/test/components/CharacterTracker.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CharacterTracker } from "../../src/components/CharacterTracker";
+
+describe("CharacterTracker", () => {
+	it("renders value and maxValue", () => {
+		render(<CharacterTracker value={42} maxValue={150} />);
+		expect(screen.getByText(/42/)).toBeInTheDocument();
+		expect(screen.getByText(/150/)).toBeInTheDocument();
+	});
+
+	it("renders zero value", () => {
+		render(<CharacterTracker value={0} maxValue={100} />);
+		expect(screen.getByText(/0/)).toBeInTheDocument();
+	});
+
+	it("renders when value equals maxValue", () => {
+		render(<CharacterTracker value={100} maxValue={100} />);
+		// Should show both numbers — rendered as "( 100 / 100 )"
+		const text = screen.getByText(/100\s*\/\s*100/);
+		expect(text).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/test/components/ErrorModal.test.tsx
+++ b/packages/frontend/test/components/ErrorModal.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { useStatefulActor } from "ts-actors-react";
+import { ErrorModal } from "../../src/components/modals/ErrorModal";
+import { withState, withNoState } from "../actorMocks";
+
+vi.mock("ts-actors-react", async importOriginal => {
+	const actual = await importOriginal<typeof import("ts-actors-react")>();
+	return { ...actual, useStatefulActor: vi.fn() };
+});
+
+// Trans renders inside a React portal outside the I18nProvider tree — mock it to avoid that
+vi.mock("@lingui/react", async importOriginal => {
+	const actual = await importOriginal<typeof import("@lingui/react")>();
+	return { ...actual, Trans: ({ id }: { id: string }) => <span>{id}</span> };
+});
+
+const mockHook = vi.mocked(useStatefulActor);
+
+function renderModal() {
+	return render(<ErrorModal />);
+}
+
+describe("ErrorModal", () => {
+	beforeEach(() => {
+		mockHook.mockReset();
+	});
+
+	it("renders nothing when actor state is not ready (nothing)", () => {
+		mockHook.mockReturnValue(withNoState() as any);
+		const { container } = renderModal();
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders nothing when error string is empty", () => {
+		mockHook.mockReturnValue(withState({ error: "" }) as any);
+		const { container } = renderModal();
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders a modal when error is set", async () => {
+		mockHook.mockReturnValue(withState({ error: "error-message-session-expired" }) as any);
+		await act(async () => {
+			renderModal();
+		});
+		// Modal should appear — react-bootstrap renders it into the document body
+		expect(document.body.querySelector(".modal")).toBeTruthy();
+	});
+
+	it("passes the error id into the modal body", async () => {
+		mockHook.mockReturnValue(withState({ error: "error-message-no-server-connection" }) as any);
+		await act(async () => {
+			renderModal();
+		});
+		// The Trans component renders its id as text when no catalog is active
+		expect(document.body).toHaveTextContent("error-message-no-server-connection");
+	});
+});

--- a/packages/frontend/test/components/InitialsBubble.test.tsx
+++ b/packages/frontend/test/components/InitialsBubble.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InitialsBubble } from "../../src/components/InitialsBubble";
+
+describe("InitialsBubble", () => {
+	it("shows first and last initials for a two-word name", () => {
+		render(<InitialsBubble username="Alice Smith" />);
+		expect(screen.getByText("AS")).toBeInTheDocument();
+	});
+
+	it("uppercases initials", () => {
+		render(<InitialsBubble username="bob jones" />);
+		expect(screen.getByText("BJ")).toBeInTheDocument();
+	});
+
+	it("renders empty string when username is undefined", () => {
+		const { container } = render(<InitialsBubble />);
+		const div = container.firstChild as HTMLElement;
+		expect(div.textContent).toBe("");
+	});
+
+	it("handles single-word name (no space)", () => {
+		// lastIndexOf(' ') returns -1, so username[-1+1] = username[0]
+		render(<InitialsBubble username="Mononym" />);
+		expect(screen.getByText("MM")).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/test/components/QuizStateBadge.test.tsx
+++ b/packages/frontend/test/components/QuizStateBadge.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QuizStateBadge } from "../../src/components/QuizStateBadge";
+
+describe("QuizStateBadge", () => {
+	it("renders the state text", () => {
+		render(<QuizStateBadge state="EDITING" />);
+		expect(screen.getByText("EDITING")).toBeInTheDocument();
+	});
+
+	it("uses primary bg for EDITING", () => {
+		const { container } = render(<QuizStateBadge state="EDITING" />);
+		expect(container.querySelector(".bg-primary")).toBeInTheDocument();
+	});
+
+	it("uses success bg for STARTED", () => {
+		const { container } = render(<QuizStateBadge state="STARTED" />);
+		expect(container.querySelector(".bg-success")).toBeInTheDocument();
+	});
+
+	it("uses warning bg for STOPPED", () => {
+		const { container } = render(<QuizStateBadge state="STOPPED" />);
+		expect(container.querySelector(".bg-warning")).toBeInTheDocument();
+	});
+
+	it("uses secondary bg for ARCHIVED", () => {
+		const { container } = render(<QuizStateBadge state="ARCHIVED" />);
+		expect(container.querySelector(".bg-secondary")).toBeInTheDocument();
+	});
+
+	it("uses secondary bg for undefined state", () => {
+		const { container } = render(<QuizStateBadge state={undefined} />);
+		expect(container.querySelector(".bg-secondary")).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/test/components/QuizzesPanel.test.tsx
+++ b/packages/frontend/test/components/QuizzesPanel.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { useStatefulActor } from "ts-actors-react";
+import type { Quiz, User, Id } from "@recapp/models";
+import { toId } from "@recapp/models";
+import { toTimestamp } from "itu-utils";
+import { QuizzesPanel } from "../../src/components/quizzes-panel/QuizzesPanel";
+import { withState, withNoState } from "../actorMocks";
+
+vi.mock("ts-actors-react", async importOriginal => {
+	const actual = await importOriginal<typeof import("ts-actors-react")>();
+	return { ...actual, useStatefulActor: vi.fn() };
+});
+
+vi.mock("@lingui/react", async importOriginal => {
+	const actual = await importOriginal<typeof import("@lingui/react")>();
+	return { ...actual, Trans: ({ id }: { id: string }) => <span>{id}</span> };
+});
+
+const mockHook = vi.mocked(useStatefulActor);
+
+function makeUser(overrides: Partial<User> = {}): User {
+	return {
+		uid: "teacher-1" as any,
+		created: toTimestamp(),
+		updated: toTimestamp(),
+		username: "Test Teacher",
+		role: "TEACHER",
+		active: true,
+		isTemporary: false,
+		...overrides,
+	} as User;
+}
+
+function makeQuiz(overrides: Partial<Quiz> = {}): Partial<Quiz> {
+	return {
+		uid: toId("quiz-1"),
+		title: "My Quiz",
+		state: "EDITING",
+		teachers: ["teacher-1" as any],
+		students: [],
+		created: toTimestamp(),
+		updated: toTimestamp(),
+		archived: undefined,
+		...overrides,
+	};
+}
+
+function makeLocalUserState(
+	quizzes: Partial<Quiz>[] = [],
+	user: User = makeUser(),
+	showArchived = false
+) {
+	const quizzesMap = new Map<Id, Partial<Quiz>>(quizzes.map(q => [q.uid!, q]));
+	return {
+		user,
+		quizzes: quizzesMap,
+		showArchived,
+		updateCounter: quizzes.length,
+		teachers: new Map<Id, string[]>(),
+		error: "",
+	};
+}
+
+function renderPanel() {
+	return render(
+		<MemoryRouter>
+			<QuizzesPanel />
+		</MemoryRouter>
+	);
+}
+
+describe("QuizzesPanel", () => {
+	beforeEach(() => {
+		mockHook.mockReset();
+	});
+
+	it("renders the filter input", () => {
+		mockHook.mockReturnValue(withState(makeLocalUserState()) as any);
+		renderPanel();
+		// The search/filter input should always be present
+		expect(screen.getByRole("searchbox")).toBeInTheDocument();
+	});
+
+	it("shows 'Create Quiz' and 'Import' buttons for non-temporary users", () => {
+		mockHook.mockReturnValue(withState(makeLocalUserState()) as any);
+		renderPanel();
+		// Non-temporary user → create and import buttons visible
+		const buttons = screen.getAllByRole("button");
+		expect(buttons.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("hides action buttons for temporary accounts", () => {
+		const tempUser = makeUser({ isTemporary: true });
+		mockHook.mockReturnValue(withState(makeLocalUserState([], tempUser)) as any);
+		renderPanel();
+		// Temporary accounts should not see create/import buttons
+		expect(screen.queryByRole("button")).toBeNull();
+	});
+
+	it("renders a quiz card for each quiz in state", () => {
+		const quizzes = [
+			makeQuiz({ uid: toId("q1"), title: "Quiz One" }),
+			makeQuiz({ uid: toId("q2"), title: "Quiz Two" }),
+		];
+		mockHook.mockReturnValue(withState(makeLocalUserState(quizzes)) as any);
+		renderPanel();
+		expect(screen.getByText("Quiz One")).toBeInTheDocument();
+		expect(screen.getByText("Quiz Two")).toBeInTheDocument();
+	});
+
+	it("hides archived quizzes when showArchived is false", () => {
+		const quizzes = [
+			makeQuiz({ uid: toId("q1"), title: "Active Quiz" }),
+			makeQuiz({ uid: toId("q2"), title: "Archived Quiz", archived: toTimestamp() }),
+		];
+		mockHook.mockReturnValue(withState(makeLocalUserState(quizzes, makeUser(), false)) as any);
+		renderPanel();
+		expect(screen.getByText("Active Quiz")).toBeInTheDocument();
+		expect(screen.queryByText("Archived Quiz")).toBeNull();
+	});
+
+	it("shows archived quizzes when showArchived is true", () => {
+		const quizzes = [
+			makeQuiz({ uid: toId("q1"), title: "Active Quiz" }),
+			makeQuiz({ uid: toId("q2"), title: "Archived Quiz", archived: toTimestamp() }),
+		];
+		mockHook.mockReturnValue(withState(makeLocalUserState(quizzes, makeUser(), true)) as any);
+		renderPanel();
+		expect(screen.getByText("Active Quiz")).toBeInTheDocument();
+		expect(screen.getByText("Archived Quiz")).toBeInTheDocument();
+	});
+
+	it("renders nothing when actor state is not ready", () => {
+		mockHook.mockReturnValue(withNoState() as any);
+		renderPanel();
+		// No quiz cards rendered; filter is still shown (panel renders unconditionally)
+		expect(screen.queryByText("Quiz One")).toBeNull();
+	});
+});
+

--- a/packages/frontend/test/components/UserCard.test.tsx
+++ b/packages/frontend/test/components/UserCard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useStatefulActor } from "ts-actors-react";
+import { nothing } from "tsmonads";
+import { toTimestamp } from "itu-utils";
+import type { User } from "@recapp/models";
+import { UserCard } from "../../src/components/cards/UserCard";
+import { withState, withNoState } from "../actorMocks";
+
+vi.mock("ts-actors-react", async importOriginal => {
+	const actual = await importOriginal<typeof import("ts-actors-react")>();
+	return { ...actual, useStatefulActor: vi.fn() };
+});
+
+vi.mock("@lingui/react", async importOriginal => {
+	const actual = await importOriginal<typeof import("@lingui/react")>();
+	return { ...actual, Trans: ({ id }: { id: string }) => <span>{id}</span> };
+});
+
+const mockHook = vi.mocked(useStatefulActor);
+
+function makeUser(overrides: Partial<User> = {}): User {
+	return {
+		uid: "user-123" as any,
+		created: toTimestamp(),
+		updated: toTimestamp(),
+		username: "Alice Teacher",
+		role: "TEACHER",
+		active: true,
+		isTemporary: false,
+		...overrides,
+	} as User;
+}
+
+function renderCard(user: User, ownUser = nothing<User>()) {
+	return render(<UserCard user={user} ownUser={ownUser} />);
+}
+
+describe("UserCard", () => {
+	beforeEach(() => {
+		// UserCard only uses the actor ref (second tuple element) for send operations
+		mockHook.mockReturnValue(withState({ users: [] }) as any);
+	});
+
+	it("renders the username", () => {
+		renderCard(makeUser({ username: "Alice Teacher" }));
+		expect(screen.getByText("Alice Teacher")).toBeInTheDocument();
+	});
+
+	it("renders the user uid", () => {
+		renderCard(makeUser({ uid: "uid-42" as any }));
+		expect(screen.getByText(/uid-42/)).toBeInTheDocument();
+	});
+
+	it("renders a green active icon for active users", () => {
+		const { container } = renderCard(makeUser({ active: true }));
+		// react-bootstrap-icons renders an SVG; check it's present
+		expect(container.querySelector("svg")).toBeTruthy();
+	});
+
+	it("renders a nickname when present", () => {
+		renderCard(makeUser({ nickname: "prof_alice" }));
+		expect(screen.getByText(/aka prof_alice/)).toBeInTheDocument();
+	});
+
+	it("renders a space placeholder when nickname is absent", () => {
+		const { container } = renderCard(makeUser({ nickname: undefined }));
+		// The italic div should exist even if nickname is absent
+		expect(container.querySelector(".fst-italic")).toBeInTheDocument();
+	});
+});

--- a/packages/frontend/test/utils/hash.test.ts
+++ b/packages/frontend/test/utils/hash.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { anonUserKey } from "../../src/utils/hash";
+
+describe("anonUserKey", () => {
+	it("returns a string starting with 'u'", () => {
+		expect(anonUserKey("user-123")).toMatch(/^u[0-9a-f]+$/);
+	});
+
+	it("is deterministic — same input gives same output", () => {
+		expect(anonUserKey("user-abc")).toBe(anonUserKey("user-abc"));
+	});
+
+	it("produces different hashes for different ids", () => {
+		expect(anonUserKey("user-1")).not.toBe(anonUserKey("user-2"));
+	});
+
+	it("salt changes the output", () => {
+		expect(anonUserKey("user-1", "quiz-A")).not.toBe(anonUserKey("user-1"));
+	});
+
+	it("same id + same salt gives same output", () => {
+		expect(anonUserKey("user-1", "quiz-A")).toBe(anonUserKey("user-1", "quiz-A"));
+	});
+
+	it("handles null id", () => {
+		expect(anonUserKey(null)).toMatch(/^u[0-9a-f]+$/);
+	});
+
+	it("handles undefined id", () => {
+		expect(anonUserKey(undefined)).toMatch(/^u[0-9a-f]+$/);
+	});
+
+	it("handles empty string id", () => {
+		expect(anonUserKey("")).toMatch(/^u[0-9a-f]+$/);
+	});
+});

--- a/packages/frontend/test/utils/utils.test.ts
+++ b/packages/frontend/test/utils/utils.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { shuffle, isMultiChoiceAnsweredCorrectly, checkIsCreatingQuestionDisabled, checkIsParticipationDisabled } from "../../src/utils";
+import type { Question } from "@recapp/models";
+
+// Minimal Question factory — only the fields isMultiChoiceAnsweredCorrectly reads
+function makeQuestion(correctFlags: boolean[]): Question {
+	return {
+		uid: "q1",
+		created: { value: 0, type: "Timestamp" },
+		updated: { value: 0, type: "Timestamp" },
+		text: "Q",
+		type: "MULTIPLE",
+		authorId: "u1",
+		quiz: "quiz1",
+		answers: correctFlags.map((correct, i) => ({ text: `opt${i}`, correct })),
+		approved: true,
+		editMode: false,
+		answerOrderFixed: false,
+	} as unknown as Question;
+}
+
+// Deterministic RNG for shuffle tests
+const seqRng = (values: number[]) => {
+	let i = 0;
+	return () => values[i++ % values.length];
+};
+
+describe("shuffle", () => {
+	it("returns the same length as input", () => {
+		const rng = seqRng([0.1, 0.5, 0.9, 0.2, 0.8]);
+		expect(shuffle(rng, [1, 2, 3, 4, 5])).toHaveLength(5);
+	});
+
+	it("contains all original elements", () => {
+		const rng = seqRng([0.9, 0.1, 0.6, 0.3, 0.7]);
+		const result = shuffle(rng, [1, 2, 3, 4, 5]);
+		expect(result.sort()).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it("returns empty array for empty input", () => {
+		expect(shuffle(() => 0.5, [])).toEqual([]);
+	});
+
+	it("returns single-element array unchanged", () => {
+		expect(shuffle(() => 0.5, ["a"])).toEqual(["a"]);
+	});
+
+	it("is curried — accepts rng first, list second", () => {
+		const shuffleWithRng = shuffle(() => 0.5);
+		expect(shuffleWithRng([1, 2, 3])).toHaveLength(3);
+	});
+});
+
+describe("isMultiChoiceAnsweredCorrectly", () => {
+	it("returns false for empty answers", () => {
+		const q = makeQuestion([true, false]);
+		expect(isMultiChoiceAnsweredCorrectly([], q)).toBe(false);
+	});
+
+	it("returns true when all answers match", () => {
+		const q = makeQuestion([true, false, true]);
+		expect(isMultiChoiceAnsweredCorrectly([true, false, true], q)).toBe(true);
+	});
+
+	it("returns false when one answer is wrong", () => {
+		const q = makeQuestion([true, false]);
+		expect(isMultiChoiceAnsweredCorrectly([false, false], q)).toBe(false);
+	});
+
+	it("pads short answer array with false", () => {
+		// question has 3 options: [true, false, false]
+		// student provides [true] — gets padded to [true, false, false] → correct
+		const q = makeQuestion([true, false, false]);
+		expect(isMultiChoiceAnsweredCorrectly([true], q)).toBe(true);
+	});
+
+	it("returns false when padding would mismatch", () => {
+		// question has [true, true]; student provides [true] → padded to [true, false] → wrong
+		const q = makeQuestion([true, true]);
+		expect(isMultiChoiceAnsweredCorrectly([true], q)).toBe(false);
+	});
+
+	it("returns false when question is undefined", () => {
+		expect(isMultiChoiceAnsweredCorrectly([true, false], undefined)).toBe(false);
+	});
+});
+
+describe("checkIsCreatingQuestionDisabled", () => {
+	it("returns true when all question types are disabled", () => {
+		expect(checkIsCreatingQuestionDisabled({ SINGLE: false, MULTIPLE: false, TEXT: false })).toBe(true);
+	});
+
+	it("returns false when at least one type is enabled", () => {
+		expect(checkIsCreatingQuestionDisabled({ SINGLE: true, MULTIPLE: false, TEXT: false })).toBe(false);
+	});
+
+	it("returns false when all types are enabled", () => {
+		expect(checkIsCreatingQuestionDisabled({ SINGLE: true, MULTIPLE: true, TEXT: true })).toBe(false);
+	});
+});
+
+describe("checkIsParticipationDisabled", () => {
+	it("returns true when all participation modes are disabled", () => {
+		expect(checkIsParticipationDisabled({ NAME: false, NICKNAME: false, ANONYMOUS: false })).toBe(true);
+	});
+
+	it("returns false when at least one mode is enabled", () => {
+		expect(checkIsParticipationDisabled({ NAME: true, NICKNAME: false, ANONYMOUS: false })).toBe(false);
+	});
+
+	it("returns false when all modes are enabled", () => {
+		expect(checkIsParticipationDisabled({ NAME: true, NICKNAME: true, ANONYMOUS: true })).toBe(false);
+	});
+});


### PR DESCRIPTION
Tier 1 — pure utils and presentational components (no mocking):
- test/utils/utils.test.ts: shuffle, isMultiChoiceAnsweredCorrectly, checkIsCreatingQuestionDisabled, checkIsParticipationDisabled
- test/utils/hash.test.ts: anonUserKey FNV-1a hash
- test/components/QuizStateBadge.test.tsx: bg class per quiz state
- test/components/InitialsBubble.test.tsx: initials computation
- test/components/CharacterTracker.test.tsx: value/maxValue render

Tier 2 — actor unit tests with local ActorSystem + stub actors:
- test/actors/stubs.ts: StubActor, createStub, getActorState helpers
- test/actors/ErrorActor.test.ts: SetError error-id mapping, ResetError
- test/actors/CreateQuizActor.test.ts: validation, CreateQuiz flow
- test/actors/SharingActor.test.ts: sync mutations + async UserStore stub

Tier 3 — component tests with vi.mock('ts-actors-react'):
- test/actorMocks.ts: withState/withNoState factories (real tsmonad instances)
- test/components/ErrorModal.test.tsx: error/no-error render paths
- test/components/UserCard.test.tsx: username, uid, role, nickname rendering
- test/components/QuizzesPanel.test.tsx: quiz list, archived filter, temp-user gate
