### PR TITLE
Implement error handling and standardize logging in backend

### DIFF
--- a/packages/backend/src/DbClient.ts
+++ b/packages/backend/src/DbClient.ts
@@ -1,5 +1,6 @@
 import { Auth, Db, MongoClient } from "mongodb";
 import { Service } from "typedi";
+import { logger } from "./logger";
 
 export const createConnection = async (): Promise<MongoClient> => {
   const { MONGODB_PORT, MONGODB_USER, MONGODB_PW, MONGODB_HOST } = process.env;
@@ -25,7 +26,7 @@ export class DbClient {
       try {
         await this.connection.connect();
       } catch (e) {
-        console.error(e);
+        logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
         throw e;
       }
     }

--- a/packages/backend/src/actors/FingerprintStore.ts
+++ b/packages/backend/src/actors/FingerprintStore.ts
@@ -4,6 +4,7 @@ import { create } from "mutative";
 import { ActorUri, Fingerprint, FingerprintStoreMessage, FingerprintStoreMessages, FingerprintUpdateMessage, Id, User, UserStoreMessage, UserStoreMessages } from "@recapp/models";
 import { identity, pick } from "rambda";
 import { CollecionSubscription, SubscribableActor } from "./SubscribableActor";
+import { logger } from "../logger";
 
 type FingerprintStoreResult = Unit | Error | Fingerprint | boolean;
 
@@ -54,7 +55,7 @@ export class FingerprintStore extends SubscribableActor<Fingerprint, Fingerprint
 					fingerprint.updated = toTimestamp();
 					const newFingerprint = { ...currentFingerprint, ...fingerprint };
 					draft.cache.set(fingerprint.uid, newFingerprint);
-					console.debug("SToring new fingerprint", newFingerprint);
+					logger.debug(`Storing new fingerprint ${JSON.stringify(newFingerprint)}`);
 					this.storeEntity(newFingerprint);
 				});
 				return unit();

--- a/packages/backend/src/actors/QuizRunActor.ts
+++ b/packages/backend/src/actors/QuizRunActor.ts
@@ -13,6 +13,7 @@ import { ActorRef, ActorSystem } from "ts-actors";
 import { Timestamp, Unit, toTimestamp, unit } from "itu-utils";
 import { create } from "mutative";
 import { identity, pick } from "rambda";
+import { logger } from "../logger";
 import { v4 } from "uuid";
 import { maybe } from "tsmonads";
 
@@ -139,7 +140,7 @@ export class QuizRunActor extends SubscribableActor<QuizRun, QuizRunActorMessage
 				Clear: async () => {
 					const db = await this.connector.db();
 					const result = await db.collection<QuizRun>(this.collectionName).deleteMany({ quizId: this.uid });
-					console.warn(result);
+					logger.warn(JSON.stringify(result));
 					this.state.cache = new Map();
 					this.state.subscribers.forEach(subscriberSet =>
 						subscriberSet.forEach(subscriber => this.send(subscriber, new QuizRunDeletedMessage()))
@@ -169,7 +170,7 @@ export class QuizRunActor extends SubscribableActor<QuizRun, QuizRunActorMessage
 				},
 			});
 		} catch (e) {
-			console.error(e);
+			logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
 			throw e;
 		}
 	}

--- a/packages/backend/src/actors/StatisticsActor.ts
+++ b/packages/backend/src/actors/StatisticsActor.ts
@@ -20,6 +20,7 @@ import { nothing } from "tsmonads";
 import * as path from "path";
 import { writeFile } from "fs/promises";
 import wk from "wkhtmltopdf";
+import { logger } from "../logger";
 
 type State = {
 	cache: Map<Id, TextElementStatistics | ChoiceElementStatistics>;
@@ -268,7 +269,7 @@ export class StatisticsActor extends SubscribableActor<
 				Clear: async () => {
 					const db = await this.connector.db();
 					const result = await db.collection(this.collectionName).deleteMany({ quizId: this.uid });
-					console.warn(result);
+					logger.warn(JSON.stringify(result));
 					this.state.cache = new Map();
 					this.state.subscribers.forEach(subscriberSet =>
 						subscriberSet.forEach(subscriber =>

--- a/packages/backend/src/actors/StoringActor.ts
+++ b/packages/backend/src/actors/StoringActor.ts
@@ -8,6 +8,7 @@ import { Draft, create } from "mutative";
 import { Timestamp, Unit, fromTimestamp, hours, toTimestamp, unit } from "itu-utils";
 import { DateTime } from "luxon";
 import { systemEquals, createActorUri, extractSystemName } from "../utils";
+import { logger } from "../logger";
 
 export const CLEANUP_INTERVAL = hours(24);
 
@@ -54,7 +55,7 @@ export abstract class StoringActor<Entity extends Document & { updated: Timestam
 		)
 			.then(s => s as Session)
 			.catch((e: Error): Session => {
-				console.error(e);
+				logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
 				return { role: "STUDENT", uid: "", fingerprint: "-"} as Session;
 			});
 		return [session.role, session.uid, !!session.fingerprint];
@@ -128,7 +129,7 @@ export abstract class StoringActor<Entity extends Document & { updated: Timestam
 		if (result.upsertedCount === 1 || result.modifiedCount === 1 || result.matchedCount === 1) {
 			return entity;
 		}
-		console.error(result);
+		logger.error(JSON.stringify(result));
 		throw new Error("FATAL: Storing a session failed");
 	};
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -59,7 +59,7 @@ const upload = multer({
     if (
       ![".json"].includes(path.extname(file.originalname).toLocaleLowerCase())
     ) {
-      console.warn(
+      logger.warn(
         `File ${file.originalname} cannot be uploaded. Wrong file format`
       );
       callback(
@@ -179,7 +179,7 @@ const start = async () => {
       errorReceiver: true,
     });
   } catch (err) {
-    console.error(err);
+    logger.error(err instanceof Error ? err.stack ?? err.message : String(err));
     process.exit(1);
   }
 };

--- a/packages/backend/src/middlewares/authRoutes.ts
+++ b/packages/backend/src/middlewares/authRoutes.ts
@@ -43,7 +43,7 @@ export const authLogin = async (ctx: koa.Context): Promise<void> => {
 	try {
 		client = await getOidc();
 	} catch (e: any) {
-		console.error("[authLogin] getOidc failed:", e?.code, e?.message, e?.stack);
+		logger.error(`[authLogin] getOidc failed: code=${String(e?.code)} message=${String(e?.message)} stack=${String(e?.stack)}`);
 		ctx.throw(400, "ID provider cannot be contacted. Login impossible");
 	}
 
@@ -82,10 +82,10 @@ export const authTempAccount = async (ctx: koa.Context): Promise<void> => {
 				userUid: uid,
 				initialQuiz: quiz && quiz !== "false" ? quiz as Id : undefined,
 			};
-			await system.send(fpStore, FingerprintStoreMessages.StoreFingerprint(fp));
+			await system.ask(fpStore, FingerprintStoreMessages.StoreFingerprint(fp));
 			fpData = fp;
 		}
-		await system.send(fpStore, FingerprintStoreMessages.IncreaseCount({ fingerprint: fingerprint as Id, userUid: uid as Id, initialQuiz: quiz && quiz !== "false" ? quiz as Id : undefined }));
+		await system.ask(fpStore, FingerprintStoreMessages.IncreaseCount({ fingerprint: fingerprint as Id, userUid: uid as Id, initialQuiz: quiz && quiz !== "false" ? quiz as Id : undefined }));
 		if (fpData.blocked) {
 			// console.debug("Fingerprint was blocked", fingerprint);
 			logger.warn(`FINGERPRINT blocked id=${String(fingerprint)}`);
@@ -93,8 +93,8 @@ export const authTempAccount = async (ctx: koa.Context): Promise<void> => {
 			return;
 		}
 	} catch (e) {
-		console.error(e);
-		console.debug("A new fingerprint has been found", fingerprint);
+		logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
+		logger.debug(`FINGERPRINT new (catch) id=${String(fingerprint)}`);
 		const fp: Fingerprint = {
 			uid: fingerprint as Id,
 			created: toTimestamp(),
@@ -105,26 +105,26 @@ export const authTempAccount = async (ctx: koa.Context): Promise<void> => {
 			userUid: uid,
 			initialQuiz: quiz && quiz !== "false" ? quiz as Id : undefined,
 		};
-		await system.send(fpStore, FingerprintStoreMessages.StoreFingerprint(fp));
-		await system.send(fpStore, FingerprintStoreMessages.IncreaseCount({ fingerprint: fingerprint as Id, userUid: uid as Id, initialQuiz: quiz && quiz !== "false" ? quiz as Id : undefined }));
+		await system.ask(fpStore, FingerprintStoreMessages.StoreFingerprint(fp));
+		await system.ask(fpStore, FingerprintStoreMessages.IncreaseCount({ fingerprint: fingerprint as Id, userUid: uid as Id, initialQuiz: quiz && quiz !== "false" ? quiz as Id : undefined }));
 	}
 	try {
 		const existingUser: User | Error = await system.ask(userStore, UserStoreMessages.GetByFingerprint(fingerprint));
 		if (existingUser instanceof Error) {
-			console.debug("A new fingerprint has been generated");
+			logger.debug("FINGERPRINT new (no existing user)");
 		} else if (!existingUser.active) {
 			ctx.redirect((process.env.FRONTEND_URI ?? "http://localhost:5173") + "?error=userdeactivated");
 			return;
 		}
 	} catch (e) {
-		console.error(e);
+		logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
 	}
 	// Wenn nicht, dann Token, temporären User und Session anlegen
 	const token = createTempJwt(uid, fingerprint);
 	const decoded = jwt.decode(token) as jwt.JwtPayload;
 	const sessionStore = createActorUri("SessionStore");
 	const expires = DateTime.fromMillis((decoded.exp ?? -1) * 1000).toUTC();
-	await system.send(
+	await system.ask(
 		userStore,
 		UserStoreMessages.Create({
 			uid,
@@ -141,7 +141,7 @@ export const authTempAccount = async (ctx: koa.Context): Promise<void> => {
 			initialQuiz: quiz && quiz !== "false" ? quiz : undefined,
 		})
 	);
-	await system.send(
+	await system.ask(
 		sessionStore,
 		SessionStoreMessages.StoreSession({
 			idToken: token,
@@ -172,7 +172,7 @@ export const authProviderCallback = async (ctx: koa.Context): Promise<void> => {
 	try {
 		client = await getOidc();
 	} catch (e) {
-		console.error(e);
+		logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
 		ctx.status = 400;
 		ctx.body = "ID provider cannot be contacted. Access impossible.";
 		return;
@@ -203,7 +203,7 @@ export const authProviderCallback = async (ctx: koa.Context): Promise<void> => {
 			try {
 				const userExists = await system.ask(userStore, UserStoreMessages.Has(uid));
 				if (!userExists) {
-					await system.send(
+					await system.ask(
 						userStore,
 						UserStoreMessages.Create({
 							uid,
@@ -242,7 +242,7 @@ export const authProviderCallback = async (ctx: koa.Context): Promise<void> => {
 				// console.log("Setting expiry to", expires.toISO(), refreshExpires.toISO());
 				logger.debug(`AUTH token expiry idToken=${String(expires.toISO())} refresh=${String(refreshExpires.toISO())}`);
 				const sessionStore = createActorUri("SessionStore");
-				system.send(
+				await system.ask(
 					sessionStore,
 					SessionStoreMessages.StoreSession({
 						idToken: tokenSet.id_token ?? "",
@@ -256,7 +256,7 @@ export const authProviderCallback = async (ctx: koa.Context): Promise<void> => {
 				);
 				ctx.set("Set-Cookie", `bearer=${tokenSet.id_token}; path=/; expires=${refreshExpires.toHTTP()}`);
 			} catch (e) {
-				console.error("authProviderCallback", e);
+				logger.error(`authProviderCallback ${e instanceof Error ? e.stack ?? e.message : String(e)}`);
 				throw e;
 			}
 			ctx.redirect((process.env.FRONTEND_URI ?? "http://localhost:5173") + "/Dashboard");
@@ -289,16 +289,16 @@ export const authLogout = async (ctx: koa.Context): Promise<void> => {
 				if (session instanceof Error) {
 					throw session;
 				}
-				await system.send(sessionStore, SessionStoreMessages.RemoveSession(session.uid));
+				await system.ask(sessionStore, SessionStoreMessages.RemoveSession(session.uid));
 				if (session.fingerprint) {
 					const userStore = createActorUri("UserStore");
-					await system.send(
+					await system.ask(
 						userStore,
 						UserStoreMessages.Remove(session.uid)
 					);
 				}
 			} catch (e) {
-				console.error("authLogout", e);
+				logger.error(`authLogout ${e instanceof Error ? e.stack ?? e.message : String(e)}`);
 				throw e;
 			}
 		},
@@ -340,13 +340,13 @@ export const authRefresh = async (ctx: koa.Context): Promise<void> => {
 						let fpData: Fingerprint = await system.ask(fpStore, FingerprintStoreMessages.Get(session.fingerprint as Id));
 						await system.ask(fpStore, FingerprintStoreMessages.IncreaseCount({ fingerprint: session.fingerprint as Id, userUid: session.uid, initialQuiz: undefined }));
 						if (fpData.blocked) {
-							system.send(sessionStore, SessionStoreMessages.RemoveSession(sub as Id));
+							await system.ask(sessionStore, SessionStoreMessages.RemoveSession(sub as Id));
 							ctx.set("Set-Cookie", `bearer=; path=/`);
 							ctx.throw(401, "Token renewal failure");
 							return;
 						}
 					} catch (e) {
-						console.error(e);
+						logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
 					}
 					const token = createTempJwt(session.uid, session.fingerprint);
 					const thirtyDaysFromNow = new Date();
@@ -362,8 +362,8 @@ export const authRefresh = async (ctx: koa.Context): Promise<void> => {
 					const decodedRefresh = jwt.decode(newTokenSet.refresh_token ?? "") as jwt.JwtPayload;
 					const expires = DateTime.fromMillis((decoded.exp ?? -1) * 1000).toUTC();
 					const refreshExpires = DateTime.fromMillis(((decodedRefresh ?? decoded).exp ?? -1) * 1000).toUTC();
-					console.log("Setting expiry to", expires.toISO(), refreshExpires.toISO());
-					system.send(
+					logger.debug(`AUTH refresh expiry idToken=${String(expires.toISO())} refresh=${String(refreshExpires.toISO())}`);
+					await system.ask(
 						sessionStore,
 						SessionStoreMessages.StoreSession({
 							uid: sub as Id,
@@ -386,12 +386,12 @@ export const authRefresh = async (ctx: koa.Context): Promise<void> => {
 				} catch (e) {
 					// console.error("Failed to renew token", e);
 					logger.warn(`AUTH failed to renew token: ${e instanceof Error ? e.stack : String(e)}`);
-					system.send(sessionStore, SessionStoreMessages.RemoveSession(sub as Id));
+					await system.ask(sessionStore, SessionStoreMessages.RemoveSession(sub as Id));
 					ctx.set("Set-Cookie", `bearer=; path=/`);
 					ctx.throw(401, "Token renewal failure");
 				}
 			} catch (e) {
-				console.error(e);
+				logger.error(e instanceof Error ? e.stack ?? e.message : String(e));
 				ctx.set("Set-Cookie", `bearer=; path=/`);
 				ctx.throw(401, "Invalid token");
 			}

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -8,6 +8,7 @@ import Container from "typedi";
 import jwt from "jsonwebtoken";
 import koa from "koa";
 import crypto from "crypto";
+import { logger } from "./logger";
 
 export const systemName = "recapp-backend";
 
@@ -100,7 +101,7 @@ export const createTempJwt = (userId: Id, fingerprint: string): any => {
 		const token = jwt.sign(payload, JWT_SECRET as jwt.Secret, options);
 		return token;
 	} catch (error) {
-		console.error("Error on creating token:", error);
+		logger.error(`Error on creating token: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
 		throw error;
 	}
 };

--- a/packages/frontend/src/pages/CreateQuiz.tsx
+++ b/packages/frontend/src/pages/CreateQuiz.tsx
@@ -27,8 +27,12 @@ export const CreateQuiz: React.FC = () => {
 	return flattenSystem(tSystem, tActor, mbState).match(
 		([system, actor, state]) => {
 			const createQuiz = async () => {
-				const uid = await system.ask(actorUris["CreateQuiz"], CreateQuizMessages.CreateQuiz());
-				nav({ pathname: "/Dashboard/Quiz" }, { state: { quizId: uid } });
+				try {
+					const uid = await system.ask(actorUris["CreateQuiz"], CreateQuizMessages.CreateQuiz());
+					nav({ pathname: "/Dashboard/Quiz" }, { state: { quizId: uid } });
+				} catch (e) {
+					console.error("CreateQuiz actor rejected:", e);
+				}
 			};
 			const { quiz, validation } = state;
 


### PR DESCRIPTION
- Race-condition fixes in [packages/backend/src/middlewares/authRoutes.ts](https://github.com/bitbacchus/recapp/blob/claude/fix-auth-race-condition-oJOKj/packages/backend/src/middlewares/authRoutes.ts) — every system.send(...) for a persisted store write is now await system.ask(...):

    authProviderCallback: the reported StoreSession bug (L245) + the Create write for new TEACHER users.
    authTempAccount: Create, StoreSession, and the two StoreFingerprint/IncreaseCount pairs (try + catch branches).
    authLogout: RemoveSession + UserStoreMessages.Remove.
    authRefresh: the un-awaited RemoveSession (blocked-fp branch), the un-awaited StoreSession, and the un-awaited RemoveSession in the renew-failure path.

- Logger standardization — replaced active console.* calls with Winston logger (added imports where missing) in authRoutes.ts, index.ts, DbClient.ts, utils.ts, [actors/StoringActor.ts](https://github.com/bitbacchus/recapp/blob/claude/fix-auth-race-condition-oJOKj/actors/StoringActor.ts), [actors/FingerprintStore.ts](https://github.com/bitbacchus/recapp/blob/claude/fix-auth-race-condition-oJOKj/actors/FingerprintStore.ts), [actors/QuizRunActor.ts](https://github.com/bitbacchus/recapp/blob/claude/fix-auth-race-condition-oJOKj/actors/QuizRunActor.ts), [actors/StatisticsActor.ts](https://github.com/bitbacchus/recapp/blob/claude/fix-auth-race-condition-oJOKj/actors/StatisticsActor.ts). Commented-out lines and lines inside /* */ blocks left untouched.