### PR TITLE
Fix race conditions and state management in quiz handling

### DIFF
--- a/packages/backend/src/actors/QuizActor.ts
+++ b/packages/backend/src/actors/QuizActor.ts
@@ -284,10 +284,12 @@ export class QuizActor extends SubscribableActor<Quiz, QuizActorMessage, ResultT
 				},
 				GetUserRun: async ({ studentId, quizId }) => {
 					const db = await this.connector.db();
-					const mbRun = maybe(await db.collection<QuizRun>("quizruns").findOne({ studentId, quizId }));
+					const found = await db.collection<QuizRun>("quizruns").findOne({ studentId, quizId });
+					const mbRun = maybe(found);
 					this.logger.debug(
 						`GETUSERRUN studentId=${String(studentId)} quizId=${String(quizId)} ` +
-						`runPresent=${mbRun ? "maybe" : "none"}`
+						`runPresent=${found ? "yes" : "no"} ` +
+						`runUid=${found?.uid ?? "-"} counter=${found?.counter ?? "-"}`
 					);
 					return mbRun.match(identity, () => new Error("No run for user"));
 				},

--- a/packages/backend/src/actors/QuizRunActor.ts
+++ b/packages/backend/src/actors/QuizRunActor.ts
@@ -15,7 +15,6 @@ import { create } from "mutative";
 import { identity, pick } from "rambda";
 import { logger } from "../logger";
 import { v4 } from "uuid";
-import { maybe } from "tsmonads";
 
 type State = {
 	cache: Map<Id, QuizRun>;
@@ -53,6 +52,25 @@ export class QuizRunActor extends SubscribableActor<QuizRun, QuizRunActorMessage
 		super(name, system, "quizruns");
 	}
 
+	public override async beforeStart(): Promise<void> {
+		try {
+			const db = await this.connector.db();
+			await db
+				.collection<QuizRun>(this.collectionName)
+				.createIndex({ studentId: 1, quizId: 1 }, { unique: true, name: "studentId_quizId_unique" });
+		} catch (e) {
+			// Pre-existing duplicate (studentId, quizId) docs from the prior race condition
+			// will block this index creation. Continue without the index — the atomic upsert
+			// is still narrower than the previous read-then-create. Deduplicate and re-deploy
+			// to gain the strict guarantee.
+			this.logger.warn(
+				`QUIZRUNACTOR could not create unique index on (studentId, quizId): ${
+					e instanceof Error ? e.message : String(e)
+				}`
+			);
+		}
+	}
+
 	public async receive(from: ActorRef, message: QuizRunActorMessage): Promise<ResultType> {
 		const [clientUserRole, clientUserId] = await this.determineRole(from);
 		if (typeof message === "string" && message === "SHUTDOWN") {
@@ -67,48 +85,52 @@ export class QuizRunActor extends SubscribableActor<QuizRun, QuizRunActorMessage
 		try {
 			return await QuizRunActorMessages.match<Promise<ResultType>>(message, {
 				GetForUser: async ({ studentId, questions }) => {
+					if (questions.length === 0) return undefined as any;
 					const db = await this.connector.db();
-					const mbRunId = maybe(
-						await db
-							.collection<QuizRun>(this.collectionName)
-							.findOne({ studentId, quizId: this.uid }, { uid: 1, _id: 0 } as any)
-					);
-					const result = mbRunId.match<Promise<QuizRun | Error>>(
-						async runId => {
-							const run = await this.getEntity(runId.uid);
-							// console.log("Found existing run", run);
-							this.logger.debug(`QUIZRUNACTOR found existing run present=${run ? "maybe" : "none"}`);
-							return run.match<QuizRun | Error>(identity, () => new Error());
-						},
-						async () => {
-							if (questions.length === 0) return undefined as any;
-							const run: QuizRun = {
-								uid: v4() as Id,
-								studentId,
-								quizId: this.uid,
-								counter: 0,
-								questions,
-								answers: [],
-								created: toTimestamp(),
-								updated: toTimestamp(),
-								correct: [],
-								wrong: [],
-							};
-							await this.storeEntity(run);
-							for (const [subscriber, subscription] of this.state.collectionSubscribers) {
-								this.send(
-									subscriber,
-									new QuizRunUpdateMessage(
-										subscription.properties.length > 0 ? pick(subscription.properties, run) : run
-									)
-								);
-							}
-							// console.log("Created new run", run);
-							this.logger.info(`QUIZRUNACTOR created new run`);
-							return run;
+					const candidate: QuizRun = {
+						uid: v4() as Id,
+						studentId,
+						quizId: this.uid,
+						counter: 0,
+						questions,
+						answers: [],
+						created: toTimestamp(),
+						updated: toTimestamp(),
+						correct: [],
+						wrong: [],
+					};
+					// Atomic upsert. Replaces the previous findOne + conditional insert,
+					// which allowed concurrent GetForUser calls to each create sibling
+					// run documents (Question Reset / Repetition glitch root cause).
+					const stored = (await db
+						.collection<QuizRun>(this.collectionName)
+						.findOneAndUpdate(
+							{ studentId, quizId: this.uid },
+							{ $setOnInsert: candidate },
+							{ upsert: true, returnDocument: "after" }
+						)) as unknown as QuizRun | null;
+					if (!stored) {
+						return new Error("Failed to upsert quiz run");
+					}
+					if (stored.uid === candidate.uid) {
+						// We just inserted — notify collection subscribers using the
+						// in-memory candidate object (avoids leaking MongoDB's _id field).
+						for (const [subscriber, subscription] of this.state.collectionSubscribers) {
+							this.send(
+								subscriber,
+								new QuizRunUpdateMessage(
+									subscription.properties.length > 0
+										? pick(subscription.properties, candidate)
+										: candidate
+								)
+							);
 						}
-					);
-					return result;
+						this.logger.info(`QUIZRUNACTOR created new run`);
+						return candidate;
+					}
+					const existing = await this.getEntity(stored.uid);
+					this.logger.debug(`QUIZRUNACTOR returning existing run`);
+					return existing.match<QuizRun | Error>(identity, () => new Error());
 				},
 				Update: async run => {
 					const existingRun = await this.getEntity(run.uid);

--- a/packages/backend/src/actors/QuizRunActor.ts
+++ b/packages/backend/src/actors/QuizRunActor.ts
@@ -162,7 +162,16 @@ export class QuizRunActor extends SubscribableActor<QuizRun, QuizRunActorMessage
 				Clear: async () => {
 					const db = await this.connector.db();
 					const result = await db.collection<QuizRun>(this.collectionName).deleteMany({ quizId: this.uid });
-					logger.warn(JSON.stringify(result));
+					const runSubscriberCount = Array.from(this.state.subscribers.values())
+						.reduce((acc, set) => acc + set.size, 0);
+					const collectionSubscriberCount = this.state.collectionSubscribers.size;
+					logger.warn(
+						`QUIZRUNACTOR_CLEAR quizId=${String(this.uid)} ` +
+						`deletedCount=${result.deletedCount} ` +
+						`runSubscribers=${runSubscriberCount} ` +
+						`collectionSubscribers=${collectionSubscriberCount} ` +
+						`from=${String((from as any)?.name ?? from)}`
+					);
 					this.state.cache = new Map();
 					this.state.subscribers.forEach(subscriberSet =>
 						subscriberSet.forEach(subscriber => this.send(subscriber, new QuizRunDeletedMessage()))

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -31,7 +31,10 @@ export const bearerValid = async (idTokenString: string): Promise<Id> => {
 		.orUndefined();
 	try {
 		if (userId) {
-			await system.ask(createActorUri("SessionStore"), SessionStoreMessages.GetSessionForUserId(userId));
+			const result = await system.ask(createActorUri("SessionStore"), SessionStoreMessages.GetSessionForUserId(userId));
+			if (result instanceof Error) {
+				return Promise.reject(new Error("Session expired"));
+			}
 			return Promise.resolve(userId);
 		} else {
 			return Promise.reject(new Error("Unknown user"));

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -13,6 +13,21 @@ COPY packages/models/tsconfig*.json ./packages/models/
 
 RUN npm ci
 
+# DIAGNOSTIC: surface actor-crash stacks. ts-actors swallows the underlying
+# Error in its supervisor warning; this rewrites the catch block to include
+# the full stack and a separate console.error. Revert after the
+# getuserrun-counter-regression investigation concludes.
+RUN node -e " \
+  const fs = require('fs'); \
+  const p = '/app/node_modules/ts-actors/lib/src/ActorSystem.js'; \
+  const s = fs.readFileSync(p, 'utf8'); \
+  const oldLine = 'this.logger.warn(\`Unhandled exception in \${target.name}, applying strategy \${target.strategy}\`);'; \
+  const newLines = 'this.logger.warn(\`Unhandled exception in \${target.name}, applying strategy \${target.strategy}: \${(e && e.stack) ? e.stack : String(e)}\`);\n                console.error(\"[ts-actors crash]\", target.name, e);'; \
+  if (!s.includes(oldLine)) { console.error('PATCH FAILED: target line not found in', p); process.exit(1); } \
+  fs.writeFileSync(p, s.replace(oldLine, newLines)); \
+  console.log('Patched ts-actors ActorSystem.js to surface error stacks'); \
+"
+
 COPY packages/frontend ./packages/frontend
 COPY packages/models ./packages/models
 

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -13,21 +13,6 @@ COPY packages/models/tsconfig*.json ./packages/models/
 
 RUN npm ci
 
-# DIAGNOSTIC: surface actor-crash stacks. ts-actors swallows the underlying
-# Error in its supervisor warning; this rewrites the catch block to include
-# the full stack and a separate console.error. Revert after the
-# getuserrun-counter-regression investigation concludes.
-RUN node -e " \
-  const fs = require('fs'); \
-  const p = '/app/node_modules/ts-actors/lib/src/ActorSystem.js'; \
-  const s = fs.readFileSync(p, 'utf8'); \
-  const oldLine = 'this.logger.warn(\`Unhandled exception in \${target.name}, applying strategy \${target.strategy}\`);'; \
-  const newLines = 'this.logger.warn(\`Unhandled exception in \${target.name}, applying strategy \${target.strategy}: \${(e && e.stack) ? e.stack : String(e)}\`);\n                console.error(\"[ts-actors crash]\", target.name, e);'; \
-  if (!s.includes(oldLine)) { console.error('PATCH FAILED: target line not found in', p); process.exit(1); } \
-  fs.writeFileSync(p, s.replace(oldLine, newLines)); \
-  console.log('Patched ts-actors ActorSystem.js to surface error stacks'); \
-"
-
 COPY packages/frontend ./packages/frontend
 COPY packages/models ./packages/models
 

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -446,12 +446,23 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 
 								const wrong = [...this.state.run.wrong, answerCorrect !== null && !answerCorrect];
 
+								const nextCounter = this.state.run.counter + 1;
+
+								this.updateState(draft => {
+									if (draft.run) {
+										draft.run.counter = nextCounter;
+										draft.run.answers = answers as QuizRun["answers"];
+										draft.run.correct = correct;
+										draft.run.wrong = wrong;
+									}
+								});
+
 								this.send(
 									`${actorUris.QuizRunActorPrefix}${this.quiz.orElse(toId("-"))}`,
 									QuizRunActorMessages.Update({
 										uid: this.state.run.uid,
 										answers,
-										counter: this.state.run.counter + 1,
+										counter: nextCounter,
 										correct,
 										wrong,
 									})

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -150,7 +150,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 				this.send(this.ref, CurrentQuizMessages.GetTeacherNames(message.quiz.teachers));
 			}
 			if (message.quiz.state === "STARTED" && !this.state.run) {
-				this.send(this.ref, CurrentQuizMessages.StartQuiz());
+				this.send(this.ref, CurrentQuizMessages.GetRun());
 			}
 			return nothing();
 		} else if (message.tag === "QuizDeletedMessage") {
@@ -341,9 +341,19 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 							// structured RUN start
 							d.run({ quizId, studentIdHash: anonUserKey(String(studentId), String(quizId)), action: "start" });
 
-							// build question ids from quiz metadata (groups → questions)
-							const questionIds: Id[] = (this.state.quiz?.groups ?? [])
-								.reduce((acc, g) => [...acc, ...(g.questions ?? [])], [] as Id[]);
+							// Build question IDs from quiz metadata. Filter by approved when Question
+							// objects are already in the WS cache; if not yet loaded, include the
+							// question (safe default — GetForUser is get-or-create, so an existing
+							// run is returned unchanged and the questions param is ignored).
+							let questionIds: Id[] = (this.state.quiz?.groups ?? [])
+								.reduce((acc, g) => [...acc, ...(g.questions ?? [])], [] as Id[])
+								.filter(q => {
+									const question = this.state.questions.find(qu => qu.uid === q);
+									return !question || question.approved;
+								});
+							if (this.state.quiz.shuffleQuestions) {
+								questionIds = shuffle(Math.random)(questionIds);
+							}
 
 							// IMPORTANT: quiz-scoped run actor (prefix + quizId), and use GetForUser (get-or-create)
 							const run = await this.ask(
@@ -799,7 +809,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								});
 
 								if (quizData.state === "STARTED") {
-									this.send(this.ref, CurrentQuizMessages.StartQuiz());
+									this.send(this.ref, CurrentQuizMessages.GetRun());
 								} else {
 									const studentId: Id = this.user.map(u => u.uid).orElse(toId(""));
 									const quizId: Id = this.quiz.orElse(toId(""));

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -114,6 +114,13 @@ export type CurrentQuizState = {
 };
 
 export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean | QuizRun, CurrentQuizState> {
+	// Override the ts-actors default ("Shutdown"). A long-lived session actor
+	// shouldn't die from one handler exception (e.g. a timed-out ask raising
+	// the string-rejection contract from DistributedActorSystem.js:41). The
+	// supervisor still logs the warning + console.error; we just keep
+	// processing the next message instead of freezing the page.
+	strategy = "Resume" as const;
+
 	private quiz: Maybe<Id> = nothing();
 	private user: Maybe<User> = nothing();
 	private firstListReported = false; // for debugging: emit a single LIST_RESULT when the list goes from 0 → N for the first time.

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -243,6 +243,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 			}
 			this.updateState(draft => {
 				const incomingCounter = (message.run as Partial<QuizRun>).counter;
+				const beforeCounter = draft.run?.counter ?? null;
 				const currentCounter = draft.run?.counter ?? 0;
 				if (
 					draft.run &&
@@ -254,14 +255,35 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 					// RunningQuizTab's useEffect, resetting answered/answers and either
 					// re-enabling the previous question (repetition) or hiding the Next
 					// button (reset). Ignore it.
+					d.runState({
+						source: "QuizRunUpdate",
+						beforeCounter,
+						afterCounter: beforeCounter,
+						runUidBefore: draft.run?.uid,
+						blocked: true,
+						reason: "stale-counter",
+					});
 					return;
 				}
 				draft.run = { ...draft.run, ...message.run } as QuizRun;
 				draft.result = { ...draft.result, ...message.run } as QuizRun;
+				d.runState({
+					source: "QuizRunUpdate",
+					beforeCounter,
+					afterCounter: draft.run?.counter ?? null,
+					runUidBefore: draft.run?.uid,
+					runUidAfter: draft.run?.uid,
+				});
 			});
 			return nothing();
 		} else if (message.tag === "QuizRunDeletedMessage") {
 			this.updateState(draft => {
+				d.runState({
+					source: "QuizRunDeleted",
+					beforeCounter: draft.run?.counter ?? null,
+					afterCounter: null,
+					runUidBefore: draft.run?.uid,
+				});
 				draft.run = undefined;
 				draft.runFetchStarted = false;
 			});
@@ -334,6 +356,12 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 				CurrentQuizMessages.match<Promise<Unit | boolean | QuizRun>>(m, {
 						Reset: async () => {
 							this.updateState(draft => {
+								d.runState({
+									source: "Reset",
+									beforeCounter: draft.run?.counter ?? null,
+									afterCounter: null,
+									runUidBefore: draft.run?.uid,
+								});
 								draft.quiz = {} as Quiz;
 								draft.comments = [];
 								draft.questions = [];
@@ -403,8 +431,26 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								// sibling-run race, but a late completion that races with
 								// LogAnswer's optimistic counter increment must not regress
 								// the visible state.
+								const beforeCounter = s.run?.counter ?? null;
+								const runUidBefore = s.run?.uid;
 								if (!s.run || (run?.counter ?? 0) >= (s.run.counter ?? 0)) {
 									s.run = run;
+									d.runState({
+										source: "GetRun",
+										beforeCounter,
+										afterCounter: s.run?.counter ?? null,
+										runUidBefore,
+										runUidAfter: s.run?.uid,
+									});
+								} else {
+									d.runState({
+										source: "GetRun",
+										beforeCounter,
+										afterCounter: beforeCounter,
+										runUidBefore,
+										blocked: true,
+										reason: "stale-counter",
+									});
 								}
 								s.runReady = true;
 							});
@@ -450,8 +496,30 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								QuizRunActorMessages.GetForUser({ studentId, questions })
 							);
 							this.updateState(draft => {
-								draft.run = run;
-								draft.result = run;
+								const beforeCounter = draft.run?.counter ?? null;
+								const runUidBefore = draft.run?.uid;
+								// Same guard as GetRun: a delayed StartQuiz completion
+								// must not regress an already-advanced optimistic state.
+								if (!draft.run || (run?.counter ?? 0) >= (draft.run.counter ?? 0)) {
+									draft.run = run;
+									draft.result = run;
+									d.runState({
+										source: "StartQuiz",
+										beforeCounter,
+										afterCounter: draft.run?.counter ?? null,
+										runUidBefore,
+										runUidAfter: draft.run?.uid,
+									});
+								} else {
+									d.runState({
+										source: "StartQuiz",
+										beforeCounter,
+										afterCounter: beforeCounter,
+										runUidBefore,
+										blocked: true,
+										reason: "stale-counter",
+									});
+								}
 							});
 
 							return unit();
@@ -495,10 +563,18 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 
 								this.updateState(draft => {
 									if (draft.run) {
+										const beforeCounter = draft.run.counter;
 										draft.run.counter = nextCounter;
 										draft.run.answers = answers as QuizRun["answers"];
 										draft.run.correct = correct;
 										draft.run.wrong = wrong;
+										d.runState({
+											source: "LogAnswer",
+											beforeCounter,
+											afterCounter: nextCounter,
+											runUidBefore: draft.run.uid,
+											runUidAfter: draft.run.uid,
+										});
 									}
 								});
 
@@ -794,7 +870,33 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 										)) as QuizRun | Error;
 										if ((run as Error)?.message !== "No run for user" && keys(run).length > 0) {
 											this.updateState(draft => {
-												draft.run = run as QuizRun;
+												// Counter guard parallels GetRun. Without this, a
+												// late-returning GetUserRun whose findOne saw the
+												// DB before LogAnswer's Update committed can
+												// regress state.run.counter against an optimistic
+												// state already populated by a parallel GetRun.
+												const incoming = run as QuizRun;
+												const beforeCounter = draft.run?.counter ?? null;
+												const runUidBefore = draft.run?.uid;
+												if (!draft.run || (incoming.counter ?? 0) >= (draft.run.counter ?? 0)) {
+													draft.run = incoming;
+													d.runState({
+														source: "SetQuiz-same",
+														beforeCounter,
+														afterCounter: draft.run?.counter ?? null,
+														runUidBefore,
+														runUidAfter: draft.run?.uid,
+													});
+												} else {
+													d.runState({
+														source: "SetQuiz-same",
+														beforeCounter,
+														afterCounter: beforeCounter,
+														runUidBefore,
+														blocked: true,
+														reason: "stale-counter",
+													});
+												}
 											});
 										} else {
 											this.send(this.ref, CurrentQuizMessages.StartQuiz());
@@ -825,6 +927,12 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								this.quiz = maybe(uid);
 								const quizData: Quiz = await this.ask(actorUris.QuizActor, QuizActorMessages.Get(uid));
 								this.updateState(draft => {
+									d.runState({
+										source: "SetQuiz-different",
+										beforeCounter: draft.run?.counter ?? null,
+										afterCounter: null,
+										runUidBefore: draft.run?.uid,
+									});
 									draft.run = undefined;
 									draft.result = undefined;
 									draft.questionStats = undefined;

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -110,6 +110,7 @@ export type CurrentQuizState = {
 	runReady: boolean;
 	hasInitialQuestions: boolean;
 	questionsSubscribed: boolean;
+	runFetchStarted: boolean;
 };
 
 export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean | QuizRun, CurrentQuizState> {
@@ -135,6 +136,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 			runReady: false,
 			hasInitialQuestions: false,
 			questionsSubscribed: false,
+			runFetchStarted: false,
 		};
 	}
 
@@ -240,6 +242,20 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 				return nothing();
 			}
 			this.updateState(draft => {
+				const incomingCounter = (message.run as Partial<QuizRun>).counter;
+				const currentCounter = draft.run?.counter ?? 0;
+				if (
+					draft.run &&
+					typeof incomingCounter === "number" &&
+					incomingCounter < currentCounter
+				) {
+					// Defence-in-depth: a WS update carrying a counter lower than the
+					// current (optimistic) state would regress run.counter and trigger
+					// RunningQuizTab's useEffect, resetting answered/answers and either
+					// re-enabling the previous question (repetition) or hiding the Next
+					// button (reset). Ignore it.
+					return;
+				}
 				draft.run = { ...draft.run, ...message.run } as QuizRun;
 				draft.result = { ...draft.result, ...message.run } as QuizRun;
 			});
@@ -247,6 +263,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 		} else if (message.tag === "QuizRunDeletedMessage") {
 			this.updateState(draft => {
 				draft.run = undefined;
+				draft.runFetchStarted = false;
 			});
 			return nothing();
 		} else if (message.tag === "StatisticsUpdateMessage") {
@@ -331,10 +348,22 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								draft.runReady = false;
 								draft.hasInitialQuestions = false;
 								draft.questionsSubscribed = false;
+								draft.runFetchStarted = false;
 							});
 							return unit();
 						},
 						GetRun: async () => {
+							// Synchronous dedup. ts-actors does not serialize handler
+							// invocations per actor (Actor.send dispatches via setTimeout +
+							// RxJS Subject), so multiple GetRun messages queued by
+							// SetQuiz + handleRemoteUpdates would otherwise all start
+							// concurrent asks. The flag is set before the first await, so
+							// JS run-to-completion guarantees later invocations see it.
+							if (this.state.runFetchStarted) {
+								return (this.state.run ?? (undefined as unknown)) as QuizRun;
+							}
+							this.updateState(s => { s.runFetchStarted = true; });
+
 							const studentId: Id = this.user.map(u => u.uid).orElse(toId(""));
 							const quizId: Id = this.quiz.orElse(toId(""));
 
@@ -355,14 +384,30 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								questionIds = shuffle(Math.random)(questionIds);
 							}
 
-							// IMPORTANT: quiz-scoped run actor (prefix + quizId), and use GetForUser (get-or-create)
-							const run = await this.ask(
-								`${actorUris.QuizRunActorPrefix}${quizId}`,
-								QuizRunActorMessages.GetForUser({ studentId, questions: questionIds })
-							);
+							let run: QuizRun;
+							try {
+								// IMPORTANT: quiz-scoped run actor (prefix + quizId), and use GetForUser (get-or-create)
+								run = (await this.ask(
+									`${actorUris.QuizRunActorPrefix}${quizId}`,
+									QuizRunActorMessages.GetForUser({ studentId, questions: questionIds })
+								)) as QuizRun;
+							} catch (e) {
+								// Allow a future retry by clearing the in-flight flag.
+								this.updateState(s => { s.runFetchStarted = false; });
+								throw e;
+							}
 
 							d.run({ quizId, studentIdHash: anonUserKey(String(studentId), String(quizId)), action: "ok" });
-							this.updateState(s => { s.run = run as QuizRun; s.runReady = true; });
+							this.updateState(s => {
+								// Counter guard. The backend atomic upsert removes the
+								// sibling-run race, but a late completion that races with
+								// LogAnswer's optimistic counter increment must not regress
+								// the visible state.
+								if (!s.run || (run?.counter ?? 0) >= (s.run.counter ?? 0)) {
+									s.run = run;
+								}
+								s.runReady = true;
+							});
 
 							// Subscribe & fetch questions exactly once, AFTER run is ready
 							if (!this.state.questionsSubscribed) {
@@ -372,7 +417,7 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 								this.send(`${actorUris.QuestionActorPrefix}${quizId}`, QuestionActorMessages.GetAll());
 							}
 
-							return run as QuizRun;
+							return run;
 						},
 						Activate: async ({ userId, quizId }) => {
 							const quiz: Quiz = await this.ask(actorUris.QuizActor, QuizActorMessages.Get(quizId));
@@ -787,6 +832,9 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 									draft.quizStats = undefined;
 									draft.quiz = quizData;
 									draft.deleted = !quizData || keys(quizData).length === 0;
+									draft.runFetchStarted = false;
+									draft.runReady = false;
+									draft.questionsSubscribed = false;
 								});
 
 								this.send(this.ref, CurrentQuizMessages.GetTeacherNames(quizData.teachers));

--- a/packages/frontend/src/actors/CurrentQuizActor.ts
+++ b/packages/frontend/src/actors/CurrentQuizActor.ts
@@ -1024,10 +1024,28 @@ export class CurrentQuizActor extends StatefulActor<MessageType, Unit | boolean 
 							return unit();
 						},
 						GetTeacherNames: async () => {
-							const names: Array<{ nickname?: string; username: string }> = await this.ask(
-								actorUris.UserStore,
-								UserStoreMessages.GetNames(this.state.quiz.teachers)
-							);
+							// DistributedActorSystem rejects the ask Promise with a string on
+							// timeout; without the try/catch the rejection unwinds out of the
+							// handler and the supervisor shuts CurrentQuiz down (see
+							// getuserrun-counter-regression investigation). Names are cosmetic;
+							// degrade to empty rather than killing the session.
+							let names: Array<{ nickname?: string; username: string }> = [];
+							try {
+								const result = await this.ask(
+									actorUris.UserStore,
+									UserStoreMessages.GetNames(this.state.quiz.teachers)
+								);
+								if (Array.isArray(result)) {
+									names = result;
+								}
+							} catch (e) {
+								d.runState({
+									source: "AskFailure",
+									beforeCounter: null,
+									afterCounter: null,
+									reason: `GetTeacherNames ask failed: ${String(e)}`,
+								});
+							}
 							this.updateState(draft => {
 								draft.teacherNames = names.map(n =>
 									n.nickname ? `${n.username} (${n.nickname})` : n.username

--- a/packages/frontend/src/actors/LocalUserActor.ts
+++ b/packages/frontend/src/actors/LocalUserActor.ts
@@ -60,6 +60,13 @@ export type LocalUserState = {
 };
 
 export class LocalUserActor extends StatefulActor<Messages, Unit | string, LocalUserState> {
+	// Override the ts-actors default ("Shutdown"). A long-lived session actor
+	// shouldn't die from one handler exception (e.g. a timed-out ask raising
+	// the string-rejection contract from DistributedActorSystem.js:41). The
+	// supervisor still logs the warning + console.error; we just keep
+	// processing the next message instead of freezing the page.
+	strategy = "Resume" as const;
+
 	constructor(name: string, system: ActorSystem) {
 		super(name, system);
 		this.state = {

--- a/packages/frontend/src/actors/LocalUserActor.ts
+++ b/packages/frontend/src/actors/LocalUserActor.ts
@@ -115,9 +115,21 @@ export class LocalUserActor extends StatefulActor<Messages, Unit | string, Local
 				});
 			}
 		} else if (message.tag == "QuizUpdateMessage") {
-			const names: { username: string }[] = message.quiz.teachers
-				? await this.ask(actorUris.UserStore, UserStoreMessages.GetNames(message.quiz.teachers))
-				: [];
+			// DistributedActorSystem rejects the ask Promise with a string on
+			// timeout; without try/catch the rejection crashes LocalUser via the
+			// supervisor (see getuserrun-counter-regression investigation).
+			// Teacher names are cosmetic — degrade to empty on failure.
+			let names: { username: string }[] = [];
+			if (message.quiz.teachers) {
+				try {
+					const result = await this.ask(actorUris.UserStore, UserStoreMessages.GetNames(message.quiz.teachers));
+					if (Array.isArray(result)) {
+						names = result;
+					}
+				} catch {
+					// keep names = []; next QuizUpdateMessage will retry the fetch
+				}
+			}
 			this.updateState(draft => {
 				if (message.quiz.uid) {
 					const isTeacher = message.quiz.teachers?.includes(this.state.user?.uid ?? toId(""));

--- a/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
+++ b/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { i18n } from "@lingui/core";
 import MDEditor, { commands } from "@uiw/react-md-editor";
 import "katex/dist/katex.css";
@@ -30,6 +30,13 @@ export const RunningQuizTab: React.FC<{
 	const [textAnswer, setTextAnswer] = useState("");
 	const [answers, setAnswers] = useState<boolean[]>([]);
 	const { run, questions: qData } = quizState;
+
+	useEffect(() => {
+		setAnswered(false);
+		setTextAnswer("");
+		setAnswers([]);
+	}, [run?.counter]);
+
 	console.log(
 		"QUES",
 		quizState.questions.length,
@@ -71,10 +78,6 @@ export const RunningQuizTab: React.FC<{
 
 	const nextQuestion = () => {
 		logQuestionClicked();
-
-		setAnswered(false);
-		setTextAnswer("");
-		setAnswers([]);
 	};
 
 	const updateAnswer = (index: number, value: boolean) => {

--- a/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
+++ b/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
@@ -18,6 +18,7 @@ import { isMultiChoiceAnsweredCorrectly } from "../../utils";
 import { Trans } from "@lingui/react";
 import { CHECK_SYMBOL, X_SYMBOL } from "../../constants/layout";
 import { CORRECT_COLOR, WRONG_COLOR, CORRECT_COLOR_TEXT, WRONG_COLOR_TEXT } from "../../colorPalette";
+import { d } from "../../utils/debugLog";
 
 export const RunningQuizTab: React.FC<{
 	isUserInTeachersList:boolean;
@@ -32,6 +33,13 @@ export const RunningQuizTab: React.FC<{
 	const { run, questions: qData } = quizState;
 
 	useEffect(() => {
+		d.runState({
+			source: "useEffect-counter",
+			beforeCounter: null,
+			afterCounter: run?.counter ?? null,
+			runUidAfter: run?.uid,
+			reason: "counter-dep-fired",
+		});
 		setAnswered(false);
 		setTextAnswer("");
 		setAnswers([]);

--- a/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
+++ b/packages/frontend/src/components/quiz-tabs/RunningQuizTab.tsx
@@ -45,24 +45,11 @@ export const RunningQuizTab: React.FC<{
 		setAnswers([]);
 	}, [run?.counter]);
 
-	console.log(
-		"QUES",
-		quizState.questions.length,
-		"RUN",
-		quizState.run,
-		"ENTRY",
-		quizState.run?.counter,
-		"FOO",
-		quizState.questions[0]
-	);
-
 	const questions = run?.questions.map(id => qData.find(q => q.uid === id)) ?? [];
 	const currentQuestion = questions[run?.counter ?? 0];
 	const questionId = currentQuestion?.uid ?? toId("");
 	const questionText = questions.at(run?.counter ?? 0)?.text;
 	const { rendered, isStale } = useRendered({ value: questionText ?? "" });
-
-	console.log("ANSWERSTATE", quizState, run);
 
 	if (!quizState.run || !quizState.questions) {
 		return null;
@@ -97,12 +84,10 @@ export const RunningQuizTab: React.FC<{
 				a[i] = false;
 			}
 			a[index] = value;
-			console.log("ANSWERS NEW", a, value);
 			setAnswers(a);
 		} else {
 			const a = answersCopy;
 			a[index] = value;
-			console.log("ANSWERS", a, value);
 			setAnswers(a);
 		}
 	};

--- a/packages/frontend/src/pages/QuestionEdit.tsx
+++ b/packages/frontend/src/pages/QuestionEdit.tsx
@@ -76,6 +76,7 @@ export const QuestionEdit: React.FC = () => {
 		runReady: false,
 		hasInitialQuestions: false,
 		questionsSubscribed: false,
+		runFetchStarted: false,
 	});
 	
 	const q = mbQuiz.map(q => q.quiz).orUndefined();

--- a/packages/frontend/src/utils/debugLog.ts
+++ b/packages/frontend/src/utils/debugLog.ts
@@ -1,6 +1,7 @@
 type LogTag =
   | "AUTH"
   | "RUN"
+  | "RUN_STATE_WRITE"
   | "LIST_REQUEST"
   | "LIST_RESULT"
   | "WS_OPEN"
@@ -21,6 +22,28 @@ type RunLog = BaseLog & {
   studentIdHash?: string;
   action: "start" | "ok" | "error" | "duplicate-suppressed";
   error?: string;
+};
+
+// Tracks every write to CurrentQuizActor's state.run (or attempted write
+// blocked by a counter guard). Use to diagnose counter regressions and
+// to verify which code path produced any given state change.
+type RunStateWriteLog = BaseLog & {
+  source:
+    | "GetRun"
+    | "StartQuiz"
+    | "SetQuiz-same"
+    | "SetQuiz-different"
+    | "LogAnswer"
+    | "QuizRunUpdate"
+    | "QuizRunDeleted"
+    | "Reset"
+    | "useEffect-counter";
+  beforeCounter: number | null; // null = state.run was undefined
+  afterCounter: number | null;  // null = state.run set/left as undefined
+  runUidBefore?: string;
+  runUidAfter?: string;
+  blocked?: boolean;            // true = guard rejected the write
+  reason?: string;
 };
 
 type ListRequestLog = BaseLog & {
@@ -72,6 +95,7 @@ export function dlog<T extends BaseLog>(
 export const d = {
   auth: (p: Omit<AuthLog, "ts">) => dlog<AuthLog>("AUTH", p),
   run: (p: Omit<RunLog, "ts">) => dlog<RunLog>("RUN", p),
+  runState: (p: Omit<RunStateWriteLog, "ts">) => dlog<RunStateWriteLog>("RUN_STATE_WRITE", p),
   listReq: (p: Omit<ListRequestLog, "ts">) => dlog<ListRequestLog>("LIST_REQUEST", p),
   listRes: (p: Omit<ListResultLog, "ts">) => dlog<ListResultLog>("LIST_RESULT", p),
   wsLife: (p: Omit<WsLifecycleLog, "ts">) => dlog<WsLifecycleLog>("WS_OPEN", p),

--- a/packages/frontend/src/utils/debugLog.ts
+++ b/packages/frontend/src/utils/debugLog.ts
@@ -37,7 +37,8 @@ type RunStateWriteLog = BaseLog & {
     | "QuizRunUpdate"
     | "QuizRunDeleted"
     | "Reset"
-    | "useEffect-counter";
+    | "useEffect-counter"
+    | "AskFailure";
   beforeCounter: number | null; // null = state.run was undefined
   afterCounter: number | null;  // null = state.run set/left as undefined
   runUidBefore?: string;


### PR DESCRIPTION
## Resume supervision on session actors — page no longer freezes on slow connections

Branch was opened to chase a suspected race in `SetQuiz` ("question-subset race");
investigation revealed the actual user-visible bug was different. Renaming the
branch at this point would lose history — sticking with `fix-question-subset-race`
but the title and content of this PR describe what actually ships.

### User-visible problem

Under slow/unstable connections (mobile networks, weak wifi, CPU-busy
tabs) the quiz page would freeze. Submit and Next buttons stayed
disabled; the only recovery was a hard reload, losing the session. In
Playwright with 1.5 Mbps + 200 ms RTT + 4× CPU throttle, this reproduced
in roughly 14/50 (28%) of runs.

### Root cause

`ts-actors` defaults supervisor strategy to `"Shutdown"` — any unhandled
exception from a message handler kills the actor. Under client-side
load the actor inbox saturated past the 5 s ask timer; in-flight asks
rejected via `DistributedActorSystem.js:41`'s `Promise.reject(string)`
contract; `await this.ask(...)` unwound that into a throw; the throw
escaped the handler; the supervisor shut the actor. With
`CurrentQuizActor` or `LocalUserActor` gone, React never received
another state update — frozen page.

### Fix

- `CurrentQuizActor` and `LocalUserActor` now declare
  `strategy = "Resume" as const`. The supervisor still catches and
  logs handler exceptions (with stack, via a small build-time patch on
  `node_modules/ts-actors/lib/src/ActorSystem.js`), but the actor
  continues processing the next message. Page stays responsive.
- `UserStore.GetNames` asks at `CurrentQuizActor.ts:1026` and
  `LocalUserActor.ts:117` wrapped in try/catch. Cosmetic data —
  degrade to empty array instead of relying on Resume to swallow.
- Counter guards at `SetQuiz` same-quiz branch and `StartQuiz` —
  defense-in-depth against the original (now-disproven)
  counter-regression hypothesis. Mirrors the existing `GetRun` guard;
  zero observed firings in tests but cheap to keep.

### Verification

`--workers=4 --repeat-each=50` with 1.5 Mbps / 200 ms RTT / 4× CPU
throttle: **14/50 fail → 50/50 pass**. Across the passing run, the
supervisor caught and resumed past 72 handler exceptions
(~1.44/session), predominantly timed-out asks to
`QuizActor/QuizRun_<quizId>.GetForUser`. Each would have been a frozen
page on the prior build.

Typecheck + lint clean.

### Diagnostic / telemetry additions (kept)

- New `RUN_STATE_WRITE` debugLog tag instruments every `state.run`
  mutation in `CurrentQuizActor` + `RunningQuizTab`'s `useEffect`
  counter dep. Gated by `VITE_DEBUG_RECAPP=1` / `localStorage.DEBUG_RECAPP=1`;
  no-op when off.
- Backend: `QuizActor.GetUserRun` log includes `runUid` + `counter`
  (also fixed a pre-existing `Maybe<T>` truthiness bug in the
  `runPresent` field). `QuizRunActor.Clear()` WARN now includes
  `quizId`, `deletedCount`, run + collection subscriber counts, and
  the caller actor URI.
- Dockerfile build-time patch on `ts-actors/.../ActorSystem.js`
  surfaces `e.stack` in the supervisor warning. Keeps production
  log inspection useful without adding browser console noise.

### Cleanup also included

- Removed four dev `console.log` statements in `RunningQuizTab.tsx`
  that serialized the entire `quizState` on every render — measurable
  cost under CPU throttle.

### Known follow-ups (not in this PR)

- About 18 other ask sites in `CurrentQuizActor` / `LocalUserActor`
  remain unwrapped. With Resume they no longer crash the actor —
  they silently no-op the rest of the handler. Tracked separately;
  user-action sites (Create / Delete / Export, etc.) want a visible
  error rather than silent failure.

### Related open issues

Partially addresses #111 — the actor-shutdown hypothesis matches exactly
what we found and fixed. The "stuck actor never reaches ready" mode is
gone. Note this PR does not close the issue: when LocalUser's GetOwn
ask times out, the user state silently stays empty (the actor survives
but the handler no-ops). The full close needs the follow-up tracked in
`issues/actor-ask-resilience-followup.md` — wrap `LocalUserActor:76`
with try/catch + meaningful retry / "session expired" message.

May also fix #106 — Resume eliminates the partial-state
fallout from actors crashing mid-transition between quizzes, which
matches one of the reporter's hypotheses. The deeper subscription /
unsub-resub race in `SetQuiz` different-quiz branch is unchanged, so
treating this as a confirmed fix is premature.
