### PR TITLE
chore: ignore deferred runtime-major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,35 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "mongodb-memory-server"
         update-types: ["version-update:semver-major"]
+      # Runtime/framework majors deliberately deferred (done as their own
+      # migration, not via auto-PRs). NOT react-router — we want the eventual
+      # fix for its RSC-CSRF advisory.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "mongodb"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "koa"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "koa-session"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@koa/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "zustand"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "zod"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "js-yaml"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "itu-utils"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@testing-library/*"
+        update-types: ["version-update:semver-major"]
 
   # Keep GitHub Actions used by the CI workflow up to date
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Adds Dependabot \`ignore\` rules suppressing **major-version** PRs for the framework/runtime deps we deliberately deferred, so they stop cluttering the PR list. Minor/patch for these still flow via the grouped PR; each major is done as its own deliberate migration.

**Ignored (major only):** react, react-dom, @types/react(-dom), mongodb, koa, koa-session, @koa/*, zustand, zod, js-yaml, itu-utils, @testing-library/*

**Deliberately NOT ignored:** react-router / react-router-dom — we want the eventual fix for its RSC-CSRF advisory.

Context: after merging the dependency-modernisation PR, Dependabot opened 15 PRs. The dev-tooling major ignores were already in place; this adds the runtime-major ones now that we have seen which reappear. Closes the noise from #135, #137, #138, #139, #140, #141, #142, #143 (those can be closed once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)