### PR TITLE
chore: hold katex minor/major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,6 +81,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@testing-library/*"
         update-types: ["version-update:semver-major"]
+      # katex 0.x: hold minor/major (0.16 -> 0.18 is a breaking render change
+      # and math rendering is core). Patch bumps (0.16.x) still flow.
+      - dependency-name: "katex"
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
 
   # Keep GitHub Actions used by the CI workflow up to date
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
katex 0.16 -> 0.18 is a breaking render change and math rendering is core to Recapp; it kept breaking the grouped minor/patch PR. Patch bumps (0.16.x) still flow. Do the 0.18 upgrade deliberately.