### PR TITLE
chore(deps): defer app-runtime major bumps via Dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,23 @@ updates:
       # and math rendering is core). Patch bumps (0.16.x) still flow.
       - dependency-name: "katex"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
+      # App runtime libs: suppress MAJOR PRs. Each is a deliberate migration,
+      # not an auto-merge (@lingui 4->6 is a coordinated cross-package move with
+      # a deprecated macro; openid-client 5->6 is an auth-API rewrite; tsmonads,
+      # rambda, serialize-error carry breaking API/ESM changes; uuid advisory is
+      # non-applicable and peer-blocked). Minor/patch still flow via the group.
+      - dependency-name: "@lingui/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "openid-client"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tsmonads"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "rambda"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "serialize-error"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "uuid"
+        update-types: ["version-update:semver-major"]
 
   # Keep GitHub Actions used by the CI workflow up to date
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Extends `.github/dependabot.yml` ignore rules to suppress **major** PRs for app-runtime libraries that are handled as deliberate migrations, not auto-merges: `@lingui/*`, `openid-client`, `tsmonads`, `rambda`, `serialize-error`, `uuid`. Minor/patch continue to flow via the grouped PR.

Closes the recurring clutter of individual major PRs (#150, #151, #152, #153, #154, #155, #156, #157, #158), which are being closed alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)