### PR TITLE
chore: gitignore Playwright E2E output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ docker/caddy/
 **/downloads/*.csv
 **/downloads/*.json
 .vscode
+
+# Playwright E2E output (generated on test runs, never commit)
+tests/e2e/test-artifacts/
+tests/e2e/test-report/


### PR DESCRIPTION
These are generated on every test run and were accidentally committed once already (removed in PR #167). Ignore tests/e2e/test-artifacts and tests/e2e/test-report so it can't happen again.